### PR TITLE
Database metadata

### DIFF
--- a/spec/databases/mysql/schema/schema.sql
+++ b/spec/databases/mysql/schema/schema.sql
@@ -12,3 +12,14 @@ CREATE TABLE IF NOT EXISTS `roles` (
   `name` VARCHAR(100) NULL,
   PRIMARY KEY (`id`))
 ENGINE = InnoDB;
+
+CREATE OR REPLACE VIEW `email_view` AS
+  SELECT users.email, users.password
+  FROM users;
+
+DELIMITER $$
+CREATE PROCEDURE `users_count`()
+BEGIN
+  SELECT COUNT(*) FROM users;
+END$$
+DELIMITER ;

--- a/spec/databases/postgresql/schema/schema.sql
+++ b/spec/databases/postgresql/schema/schema.sql
@@ -9,3 +9,12 @@ CREATE TABLE roles(
    id             SERIAL PRIMARY KEY,
    name           TEXT    NOT NULL
 );
+
+CREATE OR REPLACE VIEW email_view AS
+  SELECT users.email, users.password
+  FROM users;
+
+CREATE OR REPLACE FUNCTION user_count()
+RETURNS bigint AS $$
+  SELECT COUNT(*) FROM users AS total;
+$$ LANGUAGE SQL;

--- a/spec/databases/sqlserver/schema/schema.sql
+++ b/spec/databases/sqlserver/schema/schema.sql
@@ -17,6 +17,7 @@ END
 IF OBJECT_ID('dbo.email_view', 'V') IS NOT NULL
   DROP VIEW dbo.email_view
 GO
+
 CREATE VIEW dbo.email_view AS
 SELECT dbo.users.email, dbo.users.password
 FROM dbo.users;
@@ -24,11 +25,12 @@ FROM dbo.users;
 IF OBJECT_ID('dbo.users_count', 'P') IS NOT NULL
   DROP PROCEDURE dbo.users_count
 GO
+
 CREATE PROCEDURE dbo.users_count
 (
   @Count int OUTPUT
 )
 AS
   BEGIN
-    SELECT @Count = COUNT(*) FROM dbo.users;
+    SELECT @Count = COUNT(*) FROM dbo.users
   END

--- a/spec/databases/sqlserver/schema/schema.sql
+++ b/spec/databases/sqlserver/schema/schema.sql
@@ -14,13 +14,14 @@ CREATE TABLE dbo.roles
     name varchar(100) NULL)
 END;
 
-IF OBJECT_ID('dbo.email_view', 'V') IS NOT NULL
-  DROP VIEW dbo.email_view
+IF EXISTS (SELECT table_name FROM information_schema.views WHERE table_name = 'email_view')
+   DROP VIEW dbo.email_view
 GO
 
 CREATE VIEW dbo.email_view AS
 SELECT dbo.users.email, dbo.users.password
 FROM dbo.users;
+GO
 
 IF OBJECT_ID('dbo.users_count', 'P') IS NOT NULL
   DROP PROCEDURE dbo.users_count

--- a/spec/databases/sqlserver/schema/schema.sql
+++ b/spec/databases/sqlserver/schema/schema.sql
@@ -5,14 +5,14 @@ CREATE TABLE dbo.users
     username varchar(45) NULL,
     email varchar(150) NULL,
     password varchar(45) NULL)
-END
+END;
 
 IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = N'roles' AND type = 'U')
 BEGIN
 CREATE TABLE dbo.roles
    (id int PRIMARY KEY IDENTITY(1,1) NOT NULL,
     name varchar(100) NULL)
-END
+END;
 
 IF OBJECT_ID('dbo.email_view', 'V') IS NOT NULL
   DROP VIEW dbo.email_view

--- a/spec/databases/sqlserver/schema/schema.sql
+++ b/spec/databases/sqlserver/schema/schema.sql
@@ -13,3 +13,22 @@ CREATE TABLE dbo.roles
    (id int PRIMARY KEY IDENTITY(1,1) NOT NULL,
     name varchar(100) NULL)
 END
+
+IF OBJECT_ID('dbo.email_view', 'V') IS NOT NULL
+  DROP VIEW dbo.email_view
+GO
+CREATE VIEW dbo.email_view AS
+SELECT dbo.users.email, dbo.users.password
+FROM dbo.users;
+
+IF OBJECT_ID('dbo.users_count', 'P') IS NOT NULL
+  DROP PROCEDURE dbo.users_count
+GO
+CREATE PROCEDURE dbo.users_count
+(
+  @Count int OUTPUT
+)
+AS
+  BEGIN
+    SELECT @Count = COUNT(*) FROM dbo.users;
+  END

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -70,6 +70,28 @@ describe('db', () => {
           });
         });
 
+        describe('.listViews', () => {
+          it('should list all views', async () => {
+            const views = await dbConn.listViews();
+            expect(views).to.include.members(['email_view']);
+          });
+        });
+
+        describe('.listRoutines', () => {
+          it('should list all routines and their type', async() =>{
+            const routines = await dbConn.listRoutines();
+            expect(routines).to.have.length(1);
+            const [routine] = routines;
+
+            // Postgresql routine type is always function. SP do not exist
+            if (dbClient === 'postgresql') {
+              expect(routine).to.have.deep.property('routineType').to.eql('FUNCTION');
+            } else {
+              expect(routine).to.have.deep.property('routineType').to.eql('PROCEDURE');
+            }
+          });
+        });
+
         describe('.executeQuery', () => {
           beforeEach(() => Promise.all([
             dbConn.executeQuery(`

--- a/src/db/client.js
+++ b/src/db/client.js
@@ -18,6 +18,8 @@ export function createConnection(server, database) {
     connect: connect.bind(null, server, database),
     disconnect: disconnect.bind(null, server, database),
     listTables: listTables.bind(null, server, database),
+    listViews: listViews.bind(null, server, database),
+    listRoutines: listRoutines.bind(null, server, database),
     executeQuery: executeQuery.bind(null, server, database),
     listDatabases: listDatabases.bind(null, server, database),
     getQuerySelectTop: getQuerySelectTop.bind(null, server, database),
@@ -107,6 +109,15 @@ async function listTables(server, database) {
   return database.connection.listTables();
 }
 
+async function listViews(server, database) {
+  checkIsConnected(server, database);
+  return database.connection.listViews();
+}
+
+async function listRoutines(server, database) {
+  checkIsConnected(server, database);
+  return database.connection.listRoutines();
+}
 
 async function executeQuery(server, database, query) {
   checkIsConnected(server, database);

--- a/src/db/clients/mysql.js
+++ b/src/db/clients/mysql.js
@@ -52,6 +52,7 @@ export function listTables(client) {
       SELECT table_name
       FROM information_schema.tables
       WHERE table_schema = database()
+      AND table_type NOT LIKE '%VIEW%'
       ORDER BY table_name
     `;
     const params = [];

--- a/src/db/clients/postgresql.js
+++ b/src/db/clients/postgresql.js
@@ -23,6 +23,8 @@ export default function(server, database) {
         wrapQuery,
         disconnect: () => disconnect(client),
         listTables: () => listTables(client),
+        listViews: () => listViews(client),
+        listRoutines: () => listRoutines(client),
         executeQuery: (query) => executeQuery(client, query),
         listDatabases: () => listDatabases(client),
         getQuerySelectTop: (table, limit) => getQuerySelectTop(client, table, limit),
@@ -56,6 +58,44 @@ export function listTables(client) {
   });
 }
 
+export function listViews(client) {
+  return new Promise((resolve, reject) => {
+    const sql = `
+      SELECT table_name
+      FROM information_schema.views
+      WHERE table_schema = $1
+      ORDER BY table_name
+    `;
+    const params = [
+      'public',
+    ];
+    client.query(sql, params, (err, data) => {
+      if (err) return reject(err);
+      resolve(data.rows.map(row => row.table_name));
+    });
+  });
+}
+
+export function listRoutines(client) {
+  return new Promise((resolve, reject) => {
+    const sql = `
+      SELECT routine_name, routine_type
+      FROM information_schema.routines
+      WHERE routine_schema = $1
+      ORDER BY routine_name
+    `;
+    const params = [
+      'public',
+    ];
+    client.query(sql, params, (err, data) => {
+      if (err) return reject(err);
+      resolve(data.rows.map(row => ({
+        routineName: row.routine_name,
+        routineType: row.routine_type,
+      })));
+    });
+  });
+}
 
 export async function executeQuery(client, query) {
   // node-postgres has support for Promise query
@@ -107,6 +147,7 @@ export const truncateAllTables = async (connection) => {
     SELECT table_name
     FROM information_schema.tables
     WHERE table_schema = '${schema}'
+    AND table_type NOT LIKE '%VIEW%'
   `;
   const [result] = await executeQuery(connection, sql);
   const tables = result.rows.map(row => row.table_name);

--- a/src/db/clients/postgresql.js
+++ b/src/db/clients/postgresql.js
@@ -46,6 +46,7 @@ export function listTables(client) {
       SELECT table_name
       FROM information_schema.tables
       WHERE table_schema = $1
+      AND table_type NOT LIKE '%VIEW%'
       ORDER BY table_name
     `;
     const params = [

--- a/src/db/clients/sqlserver.js
+++ b/src/db/clients/sqlserver.js
@@ -64,6 +64,7 @@ export const listTables = async (connection) => {
   const sql = `
     SELECT table_name
     FROM information_schema.tables
+    AND table_type NOT LIKE '%VIEW%'
     ORDER BY table_name
   `;
   const [result] = await executeQuery(connection, sql);

--- a/src/db/clients/sqlserver.js
+++ b/src/db/clients/sqlserver.js
@@ -64,7 +64,7 @@ export const listTables = async (connection) => {
   const sql = `
     SELECT table_name
     FROM information_schema.tables
-    AND table_type NOT LIKE '%VIEW%'
+    WHERE table_type NOT LIKE '%VIEW%'
     ORDER BY table_name
   `;
   const [result] = await executeQuery(connection, sql);


### PR DESCRIPTION
Pull request related to [issue #98](https://github.com/sqlectron/sqlectron-gui/issues/98) on sqlectron-gui repository. As a part of solving that issue, I've implemented functions for listing views and routines which can now be used in sqelctron-gui. Since PostgreSQL only has functions as routines type, while MySQL and Microsoft SQL Server have both procedures and functions as a routines, listRoutines is returning `{ routineName, routineType }` objects, so that procedures and functions can be distributed in separate collections in GUI, if needed.

Furthermore, I added one view and routine in schema.sql for both DBs and wrote and ran specs in [db.spec.js](https://github.com/BornaP/sqlectron-core/blob/database-metadata/spec/db.spec.js) .
All tests are passing expect two regarding Microsoft SQL Server, because I don't have it installed on same machine. I'll probably make same changes for SQL Server when I'll be able to test it.
![sqlectron_tests](https://cloud.githubusercontent.com/assets/8470710/14021286/308dde86-f1db-11e5-99e2-c36c61bbe386.png)

This is it for a start, maybe latter we could fetch triggers related to specific table?

Cheers,
Borna
