### PR TITLE
Enable connecting to server without specifying database

### DIFF
--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -43,7 +43,7 @@ describe('db', () => {
         it('should connect into server without database specified', () => {
           const serverInfo = {
             ...config[dbClient],
-            database: '',
+            database: db.CLIENTS.find(c => c.key === dbClient).defaultDatabase,
             name: dbClient,
             client: dbClient,
           };

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -39,6 +39,20 @@ describe('db', () => {
 
           return expect(dbConn.connect()).to.not.be.rejected;
         });
+
+        it('should connect into server without database specified', () => {
+          const serverInfo = {
+            ...config[dbClient],
+            database: '',
+            name: dbClient,
+            client: dbClient,
+          };
+
+          const serverSession = db.createServer(serverInfo);
+          const dbConn = serverSession.createConnection(serverInfo.database);
+
+          return expect(dbConn.connect()).to.not.be.rejected;
+        });
       });
 
       describe('given is already connected', () => {

--- a/src/db/clients/index.js
+++ b/src/db/clients/index.js
@@ -8,7 +8,7 @@ import sqlserver from './sqlserver';
  */
 export const CLIENTS = [
   { key: 'mysql', name: 'MySQL' },
-  { key: 'postgresql', name: 'PostgreSQL' },
+  { key: 'postgresql', name: 'PostgreSQL', defaultDatabase: 'postgres' },
   { key: 'sqlserver', name: 'Microsoft SQL Server' },
 ];
 

--- a/src/db/clients/postgresql.js
+++ b/src/db/clients/postgresql.js
@@ -169,7 +169,7 @@ function _configDatabase(server, database) {
     port: server.config.port,
     user: server.config.user,
     password: server.config.password,
-    database: database.database,
+    database: database.database || 'postgres',
   };
 
   if (server.sshTunnel) {

--- a/src/db/clients/postgresql.js
+++ b/src/db/clients/postgresql.js
@@ -169,7 +169,7 @@ function _configDatabase(server, database) {
     port: server.config.port,
     user: server.config.user,
     password: server.config.password,
-    database: database.database || 'postgres',
+    database: database.database,
   };
 
   if (server.sshTunnel) {

--- a/src/validators/server.js
+++ b/src/validators/server.js
@@ -89,7 +89,6 @@ const SERVER_SCHEMA = {
   ],
   database: [
     { sanitizer: Valida.Sanitizer.trim },
-    { validator: Valida.Validator.required },
     { validator: Valida.Validator.len, min: 1, max: 100 },
   ],
   user: [


### PR DESCRIPTION
PR related to solving [this issue](https://github.com/sqlectron/sqlectron-gui/issues/96).

Removed database as required field in validator. PostgreSQL uses `postgres` as default database if none is specified. (as agreed on issue) + Wrote additional test.