### PR TITLE
#125 Objects SQL definition

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
   MYSQL_ENV_MYSQL_USER: root
   MYSQL_ENV_MYSQL_PASSWORD: Password12!
   MYSQL_ENV_MYSQL_DATABASE: sqlectron
-  MYSQL_PATH: C:\Program Files\MySql\MySQL Server 5.6
+  MYSQL_PATH: C:\Program Files\MySql\MySQL Server 5.7
   MYSQL_PWD: Password12!
   # sql server
   SQLSERVER_ENV_SQLSERVER_HOST: localhost

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ build_script:
   - createdb sqlectron
   - psql -d sqlectron -a -f spec/databases/postgresql/schema/schema.sql
   # mysql
-  - mysql -e "drop database test; create database sqlectron;" --user=root
+  - mysql -e "create database sqlectron;" --user=root
   - mysql sqlectron < spec/databases/mysql/schema/schema.sql --user=root
   # sqlserver
   - ps: ./appveyor-sqlserver.ps1 SQL2008R2SP2

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -174,12 +174,12 @@ describe('db', () => {
                 'ALTER TABLE users ADD CONSTRAINT users_pkey PRIMARY KEY (id)'
               );
             } else { // dbClient === SQL Server
-              expect(createScript).to.contain('CREATE TABLE users (\n' +
-                '  id int IDENTITY(1,1) NOT NULL,\n' +
-                '  username varchar(45)  NULL,\n' +
-                '  email varchar(150)  NULL,\n' +
-                '  password varchar(45)  NULL,\n' +
-                ')\n');
+              expect(createScript).to.contain('CREATE TABLE users (\r\n' +
+                '  id int IDENTITY(1,1) NOT NULL,\r\n' +
+                '  username varchar(45)  NULL,\r\n' +
+                '  email varchar(150)  NULL,\r\n' +
+                '  password varchar(45)  NULL,\r\n' +
+                ')\r\n');
               expect(createScript).to.contain('ALTER TABLE users ADD CONSTRAINT PK__users');
               expect(createScript).to.contain('PRIMARY KEY (id)');
             }
@@ -224,7 +224,7 @@ describe('db', () => {
             } else if (dbClient === 'postgresql') {
               expect(createScript).to.eql(`CREATE OR REPLACE VIEW email_view AS\n SELECT users.email,\n    users.password\n   FROM users;`);
             } else { // dbClient === SQL Server
-              expect(createScript).to.eql(`\nCREATE VIEW dbo.email_view AS\nSELECT dbo.users.email, dbo.users.password\nFROM dbo.users;`);
+              expect(createScript).to.eql(`\nCREATE VIEW dbo.email_view AS\nSELECT dbo.users.email, dbo.users.password\nFROM dbo.users;\n`);
             }
           });
         });

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -186,6 +186,39 @@ describe('db', () => {
           });
         });
 
+        describe('.getTableSelectScript', () => {
+          it('should return SELECT table script', async() => {
+            const selectQuery = await dbConn.getTableSelectScript('users');
+            expect(selectQuery).to.eql('SELECT id, username, email, password FROM users;');
+          });
+        });
+
+
+        describe('.getTableInsertScript', () => {
+          it('should return INSERT INTO table script', async() => {
+            const insertQuery = await dbConn.getTableInsertScript('users');
+            expect(insertQuery).to.eql(`INSERT INTO users (id, username, email, password)
+  VALUES (?, ?, ?, ?);`);
+          });
+        });
+
+        describe('.getTableUpdateScript', () => {
+          it('should return UPDATE table script', async() => {
+            const updateQuery = await dbConn.getTableUpdateScript('users');
+            expect(updateQuery).to.eql(`
+  UPDATE users
+     SET id=?, username=?, email=?, password=?
+   WHERE <condition>;`);
+          });
+        });
+
+        describe('.getTableDeleteScript', () => {
+          it('should return table DELETE script', async() => {
+            const deleteQuery = await dbConn.getTableDeleteScript('roles');
+            expect(deleteQuery).to.eql('DELETE FROM roles WHERE <condition>;');
+          });
+        });
+
         describe('.executeQuery', () => {
           beforeEach(() => Promise.all([
             dbConn.executeQuery(`

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -219,6 +219,20 @@ describe('db', () => {
           });
         });
 
+        describe('.getViewCreateScript', () => {
+          it('should return CREATE VIEW script', async() => {
+            const [createScript] = await dbConn.getViewCreateScript('email_view');
+
+            if (dbClient === 'mysql') {
+              expect(createScript).to.contain('VIEW `email_view` AS select `users`.`email` AS `email`,`users`.`password` AS `password` from `users`');
+            } else if (dbClient === 'postgresql') {
+              expect(createScript).to.eql(`CREATE OR REPLACE VIEW email_view AS\n SELECT users.email,\n    users.password\n   FROM users;`);
+            } else { // dbClient === SQL Server
+              expect(createScript).to.eql(`\nCREATE VIEW dbo.email_view AS\nSELECT dbo.users.email, dbo.users.password\nFROM dbo.users;`);
+            }
+          });
+        });
+
         describe('.executeQuery', () => {
           beforeEach(() => Promise.all([
             dbConn.executeQuery(`

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -92,9 +92,9 @@ describe('db', () => {
         });
 
         describe('.listRoutines', () => {
-          it('should list all routines and their type', async() =>{
+          it('should list all routines with their type and definition', async() =>{
             const routines = await dbConn.listRoutines();
-            const [routine] = routines;
+            const routine = dbClient === 'postgresql' ? routines[1] : routines[0];
 
             // Postgresql routine type is always function. SP do not exist
             // Futhermore, PostgreSQL is expected to have two functions in schema, because
@@ -105,6 +105,13 @@ describe('db', () => {
             } else {
               expect(routines).to.have.length(1);
               expect(routine).to.have.deep.property('routineType').to.eql('PROCEDURE');
+            }
+
+            // Check routine definition
+            if (dbClient === 'mssql') {
+              expect(routine).to.have.deep.property('routineDefinition').to.contain('SELECT @Count = COUNT(*) FROM dbo.users');
+            } else {
+              expect(routine).to.have.deep.property('routineDefinition').to.contain('SELECT COUNT(*) FROM users');
             }
           });
         });

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -151,6 +151,30 @@ describe('db', () => {
           });
         });
 
+        describe('.getTableCreateScript', () => {
+          it('should return table create script', async() => {
+            const [createScript] = await dbConn.getTableCreateScript('users');
+
+            if (dbClient === 'mysql') {
+              expect(createScript).to.eql('CREATE TABLE `users` (\n' +
+                '  `id` int(11) NOT NULL AUTO_INCREMENT,\n' +
+                '  `username` varchar(45) DEFAULT NULL,\n' +
+                '  `email` varchar(150) DEFAULT NULL,\n' +
+                '  `password` varchar(45) DEFAULT NULL,\n' +
+                '  PRIMARY KEY (`id`)\n' +
+              ') ENGINE=InnoDB DEFAULT CHARSET=latin1');
+            } else if (dbClient === 'postgresql') {
+              expect(createScript).to.eql('CREATE TABLE users (\n' +
+                '  id integer NOT NULL,\n' +
+                '  username text NOT NULL,\n' +
+                '  email text NOT NULL,\n' +
+                '  password text NOT NULL\n' +
+                ');'
+              );
+            }
+          });
+        });
+
         describe('.executeQuery', () => {
           beforeEach(() => Promise.all([
             dbConn.executeQuery(`

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -108,7 +108,7 @@ describe('db', () => {
             }
 
             // Check routine definition
-            if (dbClient === 'mssql') {
+            if (dbClient === 'sqlserver') {
               expect(routine).to.have.deep.property('routineDefinition').to.contain('SELECT @Count = COUNT(*) FROM dbo.users');
             } else {
               expect(routine).to.have.deep.property('routineDefinition').to.contain('SELECT COUNT(*) FROM users');
@@ -156,13 +156,13 @@ describe('db', () => {
             const [createScript] = await dbConn.getTableCreateScript('users');
 
             if (dbClient === 'mysql') {
-              expect(createScript).to.eql('CREATE TABLE `users` (\n' +
+              expect(createScript).to.contain('CREATE TABLE `users` (\n' +
                 '  `id` int(11) NOT NULL AUTO_INCREMENT,\n' +
                 '  `username` varchar(45) DEFAULT NULL,\n' +
                 '  `email` varchar(150) DEFAULT NULL,\n' +
                 '  `password` varchar(45) DEFAULT NULL,\n' +
                 '  PRIMARY KEY (`id`)\n' +
-              ') ENGINE=InnoDB DEFAULT CHARSET=latin1');
+              ') ENGINE=InnoDB');
             } else if (dbClient === 'postgresql') {
               expect(createScript).to.eql('CREATE TABLE users (\n' +
                 '  id integer NOT NULL,\n' +
@@ -174,15 +174,14 @@ describe('db', () => {
                 'ALTER TABLE users ADD CONSTRAINT users_pkey PRIMARY KEY (id)'
               );
             } else { // dbClient === SQL Server
-              expect(createScript).to.eql('CREATE TABLE users (\n' +
+              expect(createScript).to.contain('CREATE TABLE users (\n' +
                 '  id int IDENTITY(1,1) NOT NULL,\n' +
                 '  username varchar(45)  NULL,\n' +
                 '  email varchar(150)  NULL,\n' +
                 '  password varchar(45)  NULL,\n' +
-                ')\n' +
-                '\n' +
-                'ALTER TABLE users ADD CONSTRAINT PK__users__3213E83F6E4B38A9 PRIMARY KEY (id)'
-              );
+                ')\n');
+              expect(createScript).to.contain('ALTER TABLE users ADD CONSTRAINT PK__users');
+              expect(createScript).to.contain('PRIMARY KEY (id)');
             }
           });
         });

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -171,6 +171,16 @@ describe('db', () => {
                 '  password text NOT NULL\n' +
                 ');'
               );
+            } else { // dbClient === SQL Server
+              expect(createScript).to.eql('CREATE TABLE users (\n' +
+                '  id int IDENTITY(1,1) NOT NULL,\n' +
+                '  username varchar(45)  NULL,\n' +
+                '  email varchar(150)  NULL,\n' +
+                '  password varchar(45)  NULL,\n' +
+                ')\n' +
+                '\n' +
+                'ALTER TABLE users ADD CONSTRAINT PK__users__3213E83F6E4B38A9 PRIMARY KEY (id)'
+              );
             }
           });
         });

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -197,18 +197,14 @@ describe('db', () => {
         describe('.getTableInsertScript', () => {
           it('should return INSERT INTO table script', async() => {
             const insertQuery = await dbConn.getTableInsertScript('users');
-            expect(insertQuery).to.eql(`INSERT INTO users (id, username, email, password)
-  VALUES (?, ?, ?, ?);`);
+            expect(insertQuery).to.eql(`INSERT INTO users (id, username, email, password)\n VALUES (?, ?, ?, ?);`);
           });
         });
 
         describe('.getTableUpdateScript', () => {
           it('should return UPDATE table script', async() => {
             const updateQuery = await dbConn.getTableUpdateScript('users');
-            expect(updateQuery).to.eql(`
-  UPDATE users
-     SET id=?, username=?, email=?, password=?
-   WHERE <condition>;`);
+            expect(updateQuery).to.eql(`UPDATE users\n   SET id=?, username=?, email=?, password=?\n WHERE <condition>;`);
           });
         });
 

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -169,7 +169,9 @@ describe('db', () => {
                 '  username text NOT NULL,\n' +
                 '  email text NOT NULL,\n' +
                 '  password text NOT NULL\n' +
-                ');'
+                ');\n' +
+                '\n' +
+                'ALTER TABLE users ADD CONSTRAINT users_pkey PRIMARY KEY (id)'
               );
             } else { // dbClient === SQL Server
               expect(createScript).to.eql('CREATE TABLE users (\n' +

--- a/src/db/client.js
+++ b/src/db/client.js
@@ -30,6 +30,7 @@ export function createConnection(server, database) {
     getTableInsertScript: getTableInsertScript.bind(null, server, database),
     getTableUpdateScript: getTableUpdateScript.bind(null, server, database),
     getTableDeleteScript: getTableDeleteScript.bind(null, server, database),
+    getViewCreateScript: getViewCreateScript.bind(null, server, database),
     truncateAllTables: truncateAllTables.bind(null, server, database),
   };
 }
@@ -188,6 +189,11 @@ async function getTableUpdateScript(server, database, table) {
 async function getTableDeleteScript(server, database, table) {
   const condition = '<condition>';
   return `DELETE FROM ${table} WHERE ${condition};`;
+}
+
+async function getViewCreateScript(server, database, view) {
+  checkIsConnected(server, database);
+  return database.connection.getViewCreateScript(view);
 }
 
 function truncateAllTables(server, database) {

--- a/src/db/client.js
+++ b/src/db/client.js
@@ -172,18 +172,14 @@ async function getTableSelectScript(server, database, table) {
 
 async function getTableInsertScript(server, database, table) {
   const columnNames = await getTableColumnNames(server, database, table);
-  return `INSERT INTO ${table} (${columnNames.join(', ')})
-  VALUES (${columnNames.fill('?').join(', ')});`;
+  return `INSERT INTO ${table} (${columnNames.join(', ')})\n VALUES (${columnNames.fill('?').join(', ')});`;
 }
 
 async function getTableUpdateScript(server, database, table) {
   const columnNames = await getTableColumnNames(server, database, table);
   const setColumnForm = columnNames.map(columnName => `${columnName}=?`).join(', ');
   const condition = '<condition>';
-  return `
-  UPDATE ${table}
-     SET ${setColumnForm}
-   WHERE ${condition};`;
+  return `UPDATE ${table}\n   SET ${setColumnForm}\n WHERE ${condition};`;
 }
 
 async function getTableDeleteScript(server, database, table) {

--- a/src/db/client.js
+++ b/src/db/client.js
@@ -26,6 +26,10 @@ export function createConnection(server, database) {
     listDatabases: listDatabases.bind(null, server, database),
     getQuerySelectTop: getQuerySelectTop.bind(null, server, database),
     getTableCreateScript: getTableCreateScript.bind(null, server, database),
+    getTableSelectScript: getTableSelectScript.bind(null, server, database),
+    getTableInsertScript: getTableInsertScript.bind(null, server, database),
+    getTableUpdateScript: getTableUpdateScript.bind(null, server, database),
+    getTableDeleteScript: getTableDeleteScript.bind(null, server, database),
     truncateAllTables: truncateAllTables.bind(null, server, database),
   };
 }
@@ -159,10 +163,42 @@ async function getTableCreateScript(server, database, table) {
   return database.connection.getTableCreateScript(table);
 }
 
+async function getTableSelectScript(server, database, table) {
+  const columnNames = await getTableColumnNames(server, database, table);
+  return `SELECT ${columnNames.join(', ')} FROM ${table};`;
+}
+
+
+async function getTableInsertScript(server, database, table) {
+  const columnNames = await getTableColumnNames(server, database, table);
+  return `INSERT INTO ${table} (${columnNames.join(', ')})
+  VALUES (${columnNames.fill('?').join(', ')});`;
+}
+
+async function getTableUpdateScript(server, database, table) {
+  const columnNames = await getTableColumnNames(server, database, table);
+  const setColumnForm = columnNames.map(columnName => `${columnName}=?`).join(', ');
+  const condition = '<condition>';
+  return `
+  UPDATE ${table}
+     SET ${setColumnForm}
+   WHERE ${condition};`;
+}
+
+async function getTableDeleteScript(server, database, table) {
+  const condition = '<condition>';
+  return `DELETE FROM ${table} WHERE ${condition};`;
+}
+
 function truncateAllTables(server, database) {
   return database.connection.truncateAllTables();
 }
 
+async function getTableColumnNames(server, database, table) {
+  checkIsConnected(server, database);
+  const columns = await database.connection.listTableColumns(table);
+  return columns.map(column => column.columnName);
+}
 
 async function loadConfigLimit() {
   if (limitSelect === null) {

--- a/src/db/client.js
+++ b/src/db/client.js
@@ -25,6 +25,7 @@ export function createConnection(server, database) {
     executeQuery: executeQuery.bind(null, server, database),
     listDatabases: listDatabases.bind(null, server, database),
     getQuerySelectTop: getQuerySelectTop.bind(null, server, database),
+    getTableCreateScript: getTableCreateScript.bind(null, server, database),
     truncateAllTables: truncateAllTables.bind(null, server, database),
   };
 }
@@ -151,6 +152,11 @@ async function getQuerySelectTop(server, database, table, limit) {
     _limit = typeof limitSelect !== 'undefined' ? limitSelect : DEFAULT_LIMIT;
   }
   return database.connection.getQuerySelectTop(table, _limit);
+}
+
+async function getTableCreateScript(server, database, table) {
+  checkIsConnected(server, database);
+  return database.connection.getTableCreateScript(table);
 }
 
 function truncateAllTables(server, database) {

--- a/src/db/clients/mysql.js
+++ b/src/db/clients/mysql.js
@@ -36,6 +36,7 @@ export default function(server, database) {
         executeQuery: (query) => executeQuery(client, query),
         listDatabases: () => listDatabases(client),
         getQuerySelectTop: (table, limit) => getQuerySelectTop(client, table, limit),
+        getTableCreateScript: (table) => getTableCreateScript(client, table),
         truncateAllTables: () => truncateAllTables(client),
       });
     });
@@ -173,6 +174,16 @@ export function getQuerySelectTop(client, table, limit) {
   return `SELECT * FROM ${wrapQuery(table)} LIMIT ${limit}`;
 }
 
+export function getTableCreateScript(client, table) {
+  return new Promise((resolve, reject) => {
+    const sql = `SHOW CREATE TABLE ${table}`;
+    const params = [];
+    client.query(sql, params, (err, data) => {
+      if (err) return reject(_getRealError(client, err));
+      resolve(data.map(row => row['Create Table']));
+    });
+  });
+}
 
 export function wrapQuery(item) {
   return `\`${item}\``;

--- a/src/db/clients/mysql.js
+++ b/src/db/clients/mysql.js
@@ -84,7 +84,7 @@ export function listViews(client) {
 export function listRoutines(client) {
   return new Promise((resolve, reject) => {
     const sql = `
-      SELECT routine_name, routine_type
+      SELECT routine_name, routine_type, routine_definition
       FROM information_schema.routines
       WHERE routine_schema = database()
       ORDER BY routine_name
@@ -95,6 +95,7 @@ export function listRoutines(client) {
       resolve(data.map(row => ({
         routineName: row.routine_name,
         routineType: row.routine_type,
+        routineDefinition: row.routine_definition,
       })));
     });
   });

--- a/src/db/clients/mysql.js
+++ b/src/db/clients/mysql.js
@@ -37,6 +37,7 @@ export default function(server, database) {
         listDatabases: () => listDatabases(client),
         getQuerySelectTop: (table, limit) => getQuerySelectTop(client, table, limit),
         getTableCreateScript: (table) => getTableCreateScript(client, table),
+        getViewCreateScript: (view) => getViewCreateScript(client, view),
         truncateAllTables: () => truncateAllTables(client),
       });
     });
@@ -181,6 +182,17 @@ export function getTableCreateScript(client, table) {
     client.query(sql, params, (err, data) => {
       if (err) return reject(_getRealError(client, err));
       resolve(data.map(row => row['Create Table']));
+    });
+  });
+}
+
+export function getViewCreateScript(client, view) {
+  return new Promise((resolve, reject) => {
+    const sql = `SHOW CREATE VIEW ${view}`;
+    const params = [];
+    client.query(sql, params, (err, data) => {
+      if (err) return reject(_getRealError(client, err));
+      resolve(data.map(row => row['Create View']));
     });
   });
 }

--- a/src/db/clients/postgresql.js
+++ b/src/db/clients/postgresql.js
@@ -82,7 +82,7 @@ export function listViews(client) {
 export function listRoutines(client) {
   return new Promise((resolve, reject) => {
     const sql = `
-      SELECT routine_name, routine_type
+      SELECT routine_name, routine_type, routine_definition
       FROM information_schema.routines
       WHERE routine_schema = $1
       ORDER BY routine_name
@@ -95,6 +95,7 @@ export function listRoutines(client) {
       resolve(data.rows.map(row => ({
         routineName: row.routine_name,
         routineType: row.routine_type,
+        routineDefinition: row.routine_definition,
       })));
     });
   });

--- a/src/db/clients/postgresql.js
+++ b/src/db/clients/postgresql.js
@@ -31,6 +31,7 @@ export default function(server, database) {
         listDatabases: () => listDatabases(client),
         getQuerySelectTop: (table, limit) => getQuerySelectTop(client, table, limit),
         getTableCreateScript: (table) => getTableCreateScript(client, table),
+        getViewCreateScript: (view) => getViewCreateScript(client, view),
         truncateAllTables: () => truncateAllTables(client),
       });
     });
@@ -229,6 +230,18 @@ export function getTableCreateScript(client, table) {
     client.query(sql, params, (err, data) => {
       if (err) return reject(err);
       resolve(data.rows.map(row => row.createtable));
+    });
+  });
+}
+
+export function getViewCreateScript(client, view) {
+  return new Promise((resolve, reject) => {
+    const createViewSql = `CREATE OR REPLACE VIEW ${view} AS`;
+    const sql = `SELECT pg_get_viewdef($1::regclass, true)`;
+    const params = [ view ];
+    client.query(sql, params, (err, data) => {
+      if (err) return reject(err);
+      resolve(data.rows.map(row => `${createViewSql}\n${row.pg_get_viewdef}`));
     });
   });
 }

--- a/src/db/clients/sqlserver.js
+++ b/src/db/clients/sqlserver.js
@@ -26,6 +26,7 @@ export default async function(server, database) {
       executeQuery: (query) => executeQuery(connection, query),
       listDatabases: () => listDatabases(connection),
       getQuerySelectTop: (table, limit) => getQuerySelectTop(connection, table, limit),
+      getTableCreateScript: (table) => getTableCreateScript(connection, table),
       truncateAllTables: () => truncateAllTables(connection),
     };
   } catch (err) {
@@ -125,6 +126,74 @@ export const listDatabases = async (connection) => {
   return result.rows.map(row => row.name);
 };
 
+export const getTableCreateScript = async (connection, table) => {
+  // Reference http://stackoverflow.com/a/317864
+  const sql = `
+    SELECT  ('CREATE TABLE ' + so.name + ' (' +
+    	CHAR(13)+CHAR(10) + REPLACE(o.list, '&#x0D;', CHAR(13)) +
+    	')' + CHAR(13)+CHAR(10) +
+      CASE WHEN tc.Constraint_Name IS NULL THEN ''
+    	     ELSE + CHAR(13)+CHAR(10) + 'ALTER TABLE ' + so.Name +
+           ' ADD CONSTRAINT ' + tc.Constraint_Name  +
+           ' PRIMARY KEY ' + '(' + LEFT(j.List, Len(j.List)-1) + ')'
+    	END) AS createtable
+    FROM sysobjects so
+    CROSS APPLY
+      (SELECT
+        '  ' + column_name + ' ' +
+        data_type +
+        CASE data_type
+            WHEN 'sql_variant' THEN ''
+            WHEN 'text' THEN ''
+            WHEN 'ntext' THEN ''
+            WHEN 'xml' THEN ''
+            WHEN 'decimal' THEN '(' + cast(numeric_precision AS varchar) + ', '
+									+ cast(numeric_scale AS varchar) + ')'
+            ELSE coalesce('('+ CASE WHEN character_maximum_length = -1
+									THEN 'MAX'
+									ELSE cast(character_maximum_length AS varchar)
+								END + ')','')
+          END + ' ' +
+          CASE WHEN EXISTS (
+      			SELECT id FROM syscolumns
+      			WHERE object_name(id)=so.name
+      			AND name=column_name
+      			AND columnproperty(id,name,'IsIdentity') = 1
+    			) THEN
+      			'IDENTITY(' +
+      			cast(ident_seed(so.name) AS varchar) + ',' +
+      			cast(ident_incr(so.name) AS varchar) + ')'
+          ELSE ''
+          END + ' ' +
+           (CASE WHEN IS_NULLABLE = 'No'
+  			         THEN 'NOT '
+                 ELSE ''
+  		   END ) + 'NULL' +
+          CASE WHEN information_schema.columns.COLUMN_DEFAULT IS NOT NULL
+               THEN 'DEFAULT '+ information_schema.columns.COLUMN_DEFAULT
+               ELSE ''
+          END + ',' + CHAR(13)+CHAR(10)
+       FROM information_schema.columns WHERE table_name = so.name
+       ORDER BY ordinal_position
+       FOR XML PATH('')
+  	 ) o (list)
+    LEFT JOIN information_schema.table_constraints tc
+    ON  tc.Table_name       = so.Name
+    AND tc.Constraint_Type  = 'PRIMARY KEY'
+    CROSS APPLY
+        (SELECT Column_Name + ', '
+         FROM   information_schema.key_column_usage kcu
+         WHERE  kcu.Constraint_Name = tc.Constraint_Name
+         ORDER BY ORDINAL_POSITION
+         FOR XML PATH('')
+    	 ) j (list)
+    WHERE   xtype = 'U'
+    AND name    NOT IN ('dtproperties')
+    AND so.name = '${table}'
+  `;
+  const [result] = await executeQuery(connection, sql);
+  return result.rows.map(row => row.createtable);
+};
 
 export const truncateAllTables = async (connection) => {
   const schema = await getSchema(connection);

--- a/src/db/clients/sqlserver.js
+++ b/src/db/clients/sqlserver.js
@@ -85,7 +85,7 @@ export const listViews = async (connection) => {
 
 export const listRoutines = async (connection) => {
   const sql = `
-    SELECT routine_name, routine_type
+    SELECT routine_name, routine_type, routine_definition
     FROM information_schema.routines
     ORDER BY routine_name
   `;
@@ -93,6 +93,7 @@ export const listRoutines = async (connection) => {
   return result.rows.map(row => ({
     routineName: row.routine_name,
     routineType: row.routine_type,
+    routineDefinition: row.routine_definition,
   }));
 };
 

--- a/src/db/clients/sqlserver.js
+++ b/src/db/clients/sqlserver.js
@@ -27,6 +27,7 @@ export default async function(server, database) {
       listDatabases: () => listDatabases(connection),
       getQuerySelectTop: (table, limit) => getQuerySelectTop(connection, table, limit),
       getTableCreateScript: (table) => getTableCreateScript(connection, table),
+      getViewCreateScript: (view) => getViewCreateScript(connection, view),
       truncateAllTables: () => truncateAllTables(connection),
     };
   } catch (err) {
@@ -193,6 +194,12 @@ export const getTableCreateScript = async (connection, table) => {
   `;
   const [result] = await executeQuery(connection, sql);
   return result.rows.map(row => row.createtable);
+};
+
+export const getViewCreateScript = async (connection, view) => {
+  const sql = `SELECT OBJECT_DEFINITION (OBJECT_ID('${view}')) AS ViewDefinition;`;
+  const [result] = await executeQuery(connection, sql);
+  return result.rows.map(row => row.ViewDefinition);
 };
 
 export const truncateAllTables = async (connection) => {


### PR DESCRIPTION
PR based on [this issue](https://github.com/sqlectron/sqlectron-gui/issues/125).

This is still a working version. PR is opened for further discussion. Here's what's implemented:

- Routines (procedures/functions) SQL definition can now be retrieved from store.routines object (for example on user double clicking routine, it's definition could be previewed in SQL editor tab) - resolved with 839622d1dde619c7dbfe0e2a19efd499f2ff2c46

- Create table script can be fetched from database API with `getTableCreateScript` method. While it was trivial to implement this for MySQL, I reused (and slightly redefined) SQL scripts found on stackoverflow (links [PostgreSQL](https://github.com/BornaP/sqlectron-core/commit/824d06c5ed3e1c620026aee03232c7544032fd0c#diff-1e8257a7827404852fd1dfe42e66dfc1R182), [SQL Server](https://github.com/BornaP/sqlectron-core/commit/bc4f8bf02691cba03334fcd639785487cd6f0cf9#diff-475fc021358a11bff3172976a96ac2abR130)).

Now, similar can be done for Views (in fact it's the same function for MySQL). But what I had also in mind is having context menu (on right clicking a table) with SELECT/INSERT/UPDATE/DELETE scripts, similar to pgAdmin:

![sql_scripts](https://cloud.githubusercontent.com/assets/8470710/14981292/69f38118-112e-11e6-9acf-e00e9b1d7c6b.png)

At first I thought about including this to back-end, but on the second thought, these are entirely the same for each DB server since that's a SQL standard. So maybe generating scripts logic could be included directly in sqlectron-gui or in one method that returns object containing this script's for specified table. If we will choose second option I'll implement it in this same PR.