### PR TITLE
Routines sql definition

### DIFF
--- a/spec/databases/postgresql/schema/schema.sql
+++ b/spec/databases/postgresql/schema/schema.sql
@@ -14,7 +14,7 @@ CREATE OR REPLACE VIEW email_view AS
   SELECT users.email, users.password
   FROM users;
 
-CREATE OR REPLACE FUNCTION user_count()
+CREATE OR REPLACE FUNCTION users_count()
 RETURNS bigint AS $$
   SELECT COUNT(*) FROM users AS total;
 $$ LANGUAGE SQL;

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -238,7 +238,7 @@ describe('db', () => {
                 '$function$\n');
             } else { // dbClient === SQL Server
               expect(createScript).to.contain('CREATE PROCEDURE dbo.users_count');
-              expect(createScript).to.contain('( @Count int OUTPUT');
+              expect(createScript).to.contain('@Count int OUTPUT');
               expect(createScript).to.contain('SELECT @Count = COUNT(*) FROM dbo.users');
             }
           });

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -92,7 +92,7 @@ describe('db', () => {
         });
 
         describe('.listRoutines', () => {
-          it('should list all routines with their type and definition', async() =>{
+          it('should list all routines with their type', async() =>{
             const routines = await dbConn.listRoutines();
             const routine = dbClient === 'postgresql' ? routines[1] : routines[0];
 
@@ -105,13 +105,6 @@ describe('db', () => {
             } else {
               expect(routines).to.have.length(1);
               expect(routine).to.have.deep.property('routineType').to.eql('PROCEDURE');
-            }
-
-            // Check routine definition
-            if (dbClient === 'sqlserver') {
-              expect(routine).to.have.deep.property('routineDefinition').to.contain('SELECT @Count = COUNT(*) FROM dbo.users');
-            } else {
-              expect(routine).to.have.deep.property('routineDefinition').to.contain('SELECT COUNT(*) FROM users');
             }
           });
         });
@@ -225,6 +218,28 @@ describe('db', () => {
               expect(createScript).to.eql(`CREATE OR REPLACE VIEW email_view AS\n SELECT users.email,\n    users.password\n   FROM users;`);
             } else { // dbClient === SQL Server
               expect(createScript).to.eql(`\nCREATE VIEW dbo.email_view AS\nSELECT dbo.users.email, dbo.users.password\nFROM dbo.users;\n`);
+            }
+          });
+        });
+
+        describe('.getRoutineCreateScript', () => {
+          it('should return CREATE PROCEDURE/FUNCTION script', async() => {
+            const [createScript] = await dbConn.getRoutineCreateScript('users_count', 'Procedure');
+
+            if (dbClient === 'mysql') {
+              expect(createScript).to.contain('CREATE DEFINER=');
+              expect(createScript).to.contain('PROCEDURE `users_count`()\nBEGIN\n  SELECT COUNT(*) FROM users;\nEND');
+            } else if (dbClient === 'postgresql') {
+              expect(createScript).to.eql('CREATE OR REPLACE FUNCTION public.users_count()\n' +
+                ' RETURNS bigint\n' +
+                ' LANGUAGE sql\n' +
+                'AS $function$\n' +
+                '  SELECT COUNT(*) FROM users AS total;\n' +
+                '$function$\n');
+            } else { // dbClient === SQL Server
+              expect(createScript).to.contain('CREATE PROCEDURE dbo.users_count');
+              expect(createScript).to.contain('( @Count int OUTPUT');
+              expect(createScript).to.contain('SELECT @Count = COUNT(*) FROM dbo.users');
             }
           });
         });

--- a/src/db/client.js
+++ b/src/db/client.js
@@ -31,6 +31,7 @@ export function createConnection(server, database) {
     getTableUpdateScript: getTableUpdateScript.bind(null, server, database),
     getTableDeleteScript: getTableDeleteScript.bind(null, server, database),
     getViewCreateScript: getViewCreateScript.bind(null, server, database),
+    getRoutineCreateScript: getRoutineCreateScript.bind(null, server, database),
     truncateAllTables: truncateAllTables.bind(null, server, database),
   };
 }
@@ -190,6 +191,11 @@ async function getTableDeleteScript(server, database, table) {
 async function getViewCreateScript(server, database, view) {
   checkIsConnected(server, database);
   return database.connection.getViewCreateScript(view);
+}
+
+async function getRoutineCreateScript(server, database, routine, type) {
+  checkIsConnected(server, database);
+  return database.connection.getRoutineCreateScript(routine, type);
 }
 
 function truncateAllTables(server, database) {

--- a/src/db/clients/mysql.js
+++ b/src/db/clients/mysql.js
@@ -38,6 +38,7 @@ export default function(server, database) {
         getQuerySelectTop: (table, limit) => getQuerySelectTop(client, table, limit),
         getTableCreateScript: (table) => getTableCreateScript(client, table),
         getViewCreateScript: (view) => getViewCreateScript(client, view),
+        getRoutineCreateScript: (routine, type) => getRoutineCreateScript(client, routine, type),
         truncateAllTables: () => truncateAllTables(client),
       });
     });
@@ -86,7 +87,7 @@ export function listViews(client) {
 export function listRoutines(client) {
   return new Promise((resolve, reject) => {
     const sql = `
-      SELECT routine_name, routine_type, routine_definition
+      SELECT routine_name, routine_type
       FROM information_schema.routines
       WHERE routine_schema = database()
       ORDER BY routine_name
@@ -97,7 +98,6 @@ export function listRoutines(client) {
       resolve(data.map(row => ({
         routineName: row.routine_name,
         routineType: row.routine_type,
-        routineDefinition: row.routine_definition,
       })));
     });
   });
@@ -193,6 +193,16 @@ export function getViewCreateScript(client, view) {
     client.query(sql, params, (err, data) => {
       if (err) return reject(_getRealError(client, err));
       resolve(data.map(row => row['Create View']));
+    });
+  });
+}
+
+export function getRoutineCreateScript(client, routine, type) {
+  return new Promise((resolve, reject) => {
+    const sql = `SHOW CREATE ${type.toUpperCase()} ${routine}`;
+    client.query(sql, (err, data) => {
+      if (err) return reject(_getRealError(client, err));
+      resolve(data.map(row => row[`Create ${type}`]));
     });
   });
 }

--- a/src/db/clients/sqlserver.js
+++ b/src/db/clients/sqlserver.js
@@ -28,6 +28,7 @@ export default async function(server, database) {
       getQuerySelectTop: (table, limit) => getQuerySelectTop(connection, table, limit),
       getTableCreateScript: (table) => getTableCreateScript(connection, table),
       getViewCreateScript: (view) => getViewCreateScript(connection, view),
+      getRoutineCreateScript: (routine) => getRoutineCreateScript(connection, routine),
       truncateAllTables: () => truncateAllTables(connection),
     };
   } catch (err) {
@@ -87,7 +88,7 @@ export const listViews = async (connection) => {
 
 export const listRoutines = async (connection) => {
   const sql = `
-    SELECT routine_name, routine_type, routine_definition
+    SELECT routine_name, routine_type
     FROM information_schema.routines
     ORDER BY routine_name
   `;
@@ -95,7 +96,6 @@ export const listRoutines = async (connection) => {
   return result.rows.map(row => ({
     routineName: row.routine_name,
     routineType: row.routine_type,
-    routineDefinition: row.routine_definition,
   }));
 };
 
@@ -200,6 +200,16 @@ export const getViewCreateScript = async (connection, view) => {
   const sql = `SELECT OBJECT_DEFINITION (OBJECT_ID('${view}')) AS ViewDefinition;`;
   const [result] = await executeQuery(connection, sql);
   return result.rows.map(row => row.ViewDefinition);
+};
+
+export const getRoutineCreateScript = async (connection, routine) => {
+  const sql = `
+    SELECT routine_definition
+    FROM information_schema.routines
+    WHERE routine_name = ${routine}
+  `;
+  const [result] = await executeQuery(connection, sql);
+  return result.rows.map(row => row.routine_definition);
 };
 
 export const truncateAllTables = async (connection) => {

--- a/src/db/clients/sqlserver.js
+++ b/src/db/clients/sqlserver.js
@@ -206,7 +206,7 @@ export const getRoutineCreateScript = async (connection, routine) => {
   const sql = `
     SELECT routine_definition
     FROM information_schema.routines
-    WHERE routine_name = ${routine}
+    WHERE routine_name = '${routine}'
   `;
   const [result] = await executeQuery(connection, sql);
   return result.rows.map(row => row.routine_definition);


### PR DESCRIPTION
As announced in [another PR](https://github.com/sqlectron/sqlectron-gui/pull/141), I extracted fetching routines SQL definition in a separate method that can be called on API. This way, routines are defined with CREATE statements which is cleaner and enables user to copy/paste that code in order to create/replace similar or same function/procedure somewhere else. Or for handling routines in any other use cases.