### PR TITLE
Avoid cast DB types to native JS Date Objects

### DIFF
--- a/spec/databases/mysql/schema/schema.sql
+++ b/spec/databases/mysql/schema/schema.sql
@@ -3,6 +3,7 @@ CREATE TABLE IF NOT EXISTS `users` (
   `username` VARCHAR(45) NULL,
   `email` VARCHAR(150) NULL,
   `password` VARCHAR(45) NULL,
+  `createdat` DATETIME NULL,
   PRIMARY KEY (`id`))
 ENGINE = InnoDB;
 

--- a/spec/databases/postgresql/schema/schema.sql
+++ b/spec/databases/postgresql/schema/schema.sql
@@ -2,7 +2,8 @@ CREATE TABLE users(
    id             SERIAL PRIMARY KEY,
    username       TEXT    NOT NULL,
    email          TEXT    NOT NULL,
-   password       TEXT    NOT NULL
+   password       TEXT    NOT NULL,
+   createdat      DATE    NULL
 );
 
 CREATE TABLE roles(

--- a/spec/databases/sqlserver/schema/schema.sql
+++ b/spec/databases/sqlserver/schema/schema.sql
@@ -4,7 +4,8 @@ CREATE TABLE dbo.users
    (id int PRIMARY KEY IDENTITY(1,1) NOT NULL,
     username varchar(45) NULL,
     email varchar(150) NULL,
-    password varchar(45) NULL)
+    password varchar(45) NULL,
+    createdat datetime NULL)
 END;
 
 IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = N'roles' AND type = 'U')

--- a/src/db/clients/mysql.js
+++ b/src/db/clients/mysql.js
@@ -244,6 +244,9 @@ function _configDatabase(server, database) {
     password: server.config.password,
     database: database.database,
     multipleStatements: true,
+    dateStrings: true,
+    supportBigNumbers: true,
+    bigNumberStrings: true,
   };
 
   if (server.sshTunnel) {

--- a/src/db/clients/postgresql.js
+++ b/src/db/clients/postgresql.js
@@ -1,8 +1,18 @@
-import { Client } from 'pg';
+import pg, { Client } from 'pg';
 import { identify } from 'sql-query-identifier';
 
 
 const debug = require('../../debug')('db:clients:postgresql');
+
+
+/**
+ * Do not convert DATE types to JS date.
+ * It gnores of applying a wrong timezone to the date.
+ * TODO: do not convert as well these same types with array (types 1115, 1182, 1185)
+ */
+pg.types.setTypeParser(1082, 'text', val => val); // date
+pg.types.setTypeParser(1114, 'text', val => val); // timestamp without timezone
+pg.types.setTypeParser(1184, 'text', val => val); // timestamp
 
 
 export default function(server, database) {


### PR DESCRIPTION
We have some problems on GUI (https://github.com/sqlectron/sqlectron-gui/issues/117)
because the timezone is applied to the date value. Avoid this parse to native JS Object
will ensure is not applying any timezone. Is the exactly value that is stored in the DB.

It is only implemented to PG and MySQL.
MMSQL does not have support to avoid parse to native JS Object.