### PR TITLE
Extends API: Get table foreign key references

### DIFF
--- a/spec/databases/mysql/schema/schema.sql
+++ b/spec/databases/mysql/schema/schema.sql
@@ -1,18 +1,19 @@
-CREATE TABLE IF NOT EXISTS `users` (
-  `id` INT NOT NULL AUTO_INCREMENT,
-  `username` VARCHAR(45) NULL,
-  `email` VARCHAR(150) NULL,
-  `password` VARCHAR(45) NULL,
-  `createdat` DATETIME NULL,
-  PRIMARY KEY (`id`))
-ENGINE = InnoDB;
-
-
 CREATE TABLE IF NOT EXISTS `roles` (
   `id` INT NOT NULL AUTO_INCREMENT,
   `name` VARCHAR(100) NULL,
   PRIMARY KEY (`id`))
 ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS `users` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `username` VARCHAR(45) NULL,
+  `email` VARCHAR(150) NULL,
+  `password` VARCHAR(45) NULL,
+  `role_id` INT,
+  `createdat` DATETIME NULL,
+  PRIMARY KEY (`id`),
+  FOREIGN KEY (role_id) REFERENCES roles (id) ON DELETE CASCADE
+) ENGINE = InnoDB;
 
 CREATE OR REPLACE VIEW `email_view` AS
   SELECT users.email, users.password

--- a/spec/databases/postgresql/schema/schema.sql
+++ b/spec/databases/postgresql/schema/schema.sql
@@ -1,14 +1,15 @@
+CREATE TABLE roles(
+   id             SERIAL PRIMARY KEY,
+   name           TEXT    NOT NULL
+);
+
 CREATE TABLE users(
    id             SERIAL PRIMARY KEY,
    username       TEXT    NOT NULL,
    email          TEXT    NOT NULL,
    password       TEXT    NOT NULL,
+   role_id        INT REFERENCES roles (id) ON DELETE CASCADE,
    createdat      DATE    NULL
-);
-
-CREATE TABLE roles(
-   id             SERIAL PRIMARY KEY,
-   name           TEXT    NOT NULL
 );
 
 CREATE OR REPLACE VIEW email_view AS

--- a/spec/databases/sqlserver/schema/schema.sql
+++ b/spec/databases/sqlserver/schema/schema.sql
@@ -1,3 +1,10 @@
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = N'roles' AND type = 'U')
+BEGIN
+CREATE TABLE dbo.roles
+   (id int PRIMARY KEY IDENTITY(1,1) NOT NULL,
+    name varchar(100) NULL)
+END;
+
 IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = N'users' AND type = 'U')
 BEGIN
 CREATE TABLE dbo.users
@@ -5,14 +12,9 @@ CREATE TABLE dbo.users
     username varchar(45) NULL,
     email varchar(150) NULL,
     password varchar(45) NULL,
-    createdat datetime NULL)
-END;
-
-IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = N'roles' AND type = 'U')
-BEGIN
-CREATE TABLE dbo.roles
-   (id int PRIMARY KEY IDENTITY(1,1) NOT NULL,
-    name varchar(100) NULL)
+    role_id int NULL,
+    createdat datetime NULL,
+    CONSTRAINT fk_user_role FOREIGN KEY (role_id) REFERENCES roles (id))
 END;
 
 IF EXISTS (SELECT table_name FROM information_schema.views WHERE table_name = 'email_view')

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -112,15 +112,16 @@ describe('db', () => {
         describe('.listTableColumns', () => {
           it('should list all columns and their type from users table', async() => {
             const columns = await dbConn.listTableColumns('users');
-            expect(columns).to.have.length(5);
+            expect(columns).to.have.length(6);
 
-            const [firstCol, secondCol, thirdCol, fourthCol, fifthCol ] = columns;
+            const [firstCol, secondCol, thirdCol, fourthCol, fifthCol, sixthCol ] = columns;
 
             expect(firstCol).to.have.property('columnName').to.eql('id');
             expect(secondCol).to.have.property('columnName').to.eql('username');
             expect(thirdCol).to.have.property('columnName').to.eql('email');
             expect(fourthCol).to.have.property('columnName').to.eql('password');
-            expect(fifthCol).to.have.property('columnName').to.eql('createdat');
+            expect(fifthCol).to.have.property('columnName').to.eql('role_id');
+            expect(sixthCol).to.have.property('columnName').to.eql('createdat');
 
             expect(firstCol).to.have.property('dataType').to.have.string('int');
 
@@ -131,12 +132,14 @@ describe('db', () => {
               expect(secondCol).to.have.property('dataType').to.eql('text');
               expect(thirdCol).to.have.property('dataType').to.eql('text');
               expect(fourthCol).to.have.property('dataType').to.eql('text');
-              expect(fifthCol).to.have.property('dataType').to.eql('date');
+              expect(fifthCol).to.have.property('dataType').to.eql('integer');
+              expect(sixthCol).to.have.property('dataType').to.eql('date');
             } else {
               expect(secondCol).to.have.property('dataType').to.eql('varchar');
               expect(thirdCol).to.have.property('dataType').to.eql('varchar');
               expect(fourthCol).to.have.property('dataType').to.eql('varchar');
-              expect(fifthCol).to.have.property('dataType').to.eql('datetime');
+              expect(fifthCol).to.have.property('dataType').to.eql('int');
+              expect(sixthCol).to.have.property('dataType').to.eql('datetime');
             }
           });
         });
@@ -159,8 +162,11 @@ describe('db', () => {
                 '  `username` varchar(45) DEFAULT NULL,\n' +
                 '  `email` varchar(150) DEFAULT NULL,\n' +
                 '  `password` varchar(45) DEFAULT NULL,\n' +
+                '  `role_id` int(11) DEFAULT NULL,\n' +
                 '  `createdat` datetime DEFAULT NULL,\n' +
-                '  PRIMARY KEY (`id`)\n' +
+                '  PRIMARY KEY (`id`),\n' +
+                '  KEY `role_id` (`role_id`),\n' +
+                '  CONSTRAINT `users_ibfk_1` FOREIGN KEY (`role_id`) REFERENCES `roles` (`id`) ON DELETE CASCADE\n' +
               ') ENGINE=InnoDB');
             } else if (dbClient === 'postgresql') {
               expect(createScript).to.eql('CREATE TABLE users (\n' +
@@ -168,6 +174,7 @@ describe('db', () => {
                 '  username text NOT NULL,\n' +
                 '  email text NOT NULL,\n' +
                 '  password text NOT NULL,\n' +
+                '  role_id integer NULL,\n' +
                 '  createdat date NULL\n' +
                 ');\n' +
                 '\n' +
@@ -179,6 +186,7 @@ describe('db', () => {
                 '  username varchar(45)  NULL,\r\n' +
                 '  email varchar(150)  NULL,\r\n' +
                 '  password varchar(45)  NULL,\r\n' +
+                '  role_id int  NULL,\r\n' +
                 '  createdat datetime  NULL,\r\n' +
                 ')\r\n');
               expect(createScript).to.contain('ALTER TABLE users ADD CONSTRAINT PK__users');
@@ -190,7 +198,7 @@ describe('db', () => {
         describe('.getTableSelectScript', () => {
           it('should return SELECT table script', async() => {
             const selectQuery = await dbConn.getTableSelectScript('users');
-            expect(selectQuery).to.eql('SELECT id, username, email, password, createdat FROM users;');
+            expect(selectQuery).to.eql('SELECT id, username, email, password, role_id, createdat FROM users;');
           });
         });
 
@@ -198,14 +206,14 @@ describe('db', () => {
         describe('.getTableInsertScript', () => {
           it('should return INSERT INTO table script', async() => {
             const insertQuery = await dbConn.getTableInsertScript('users');
-            expect(insertQuery).to.eql(`INSERT INTO users (id, username, email, password, createdat)\n VALUES (?, ?, ?, ?, ?);`);
+            expect(insertQuery).to.eql(`INSERT INTO users (id, username, email, password, role_id, createdat)\n VALUES (?, ?, ?, ?, ?, ?);`);
           });
         });
 
         describe('.getTableUpdateScript', () => {
           it('should return UPDATE table script', async() => {
             const updateQuery = await dbConn.getTableUpdateScript('users');
-            expect(updateQuery).to.eql(`UPDATE users\n   SET id=?, username=?, email=?, password=?, createdat=?\n WHERE <condition>;`);
+            expect(updateQuery).to.eql(`UPDATE users\n   SET id=?, username=?, email=?, password=?, role_id=?, createdat=?\n WHERE <condition>;`);
           });
         });
 
@@ -255,12 +263,12 @@ describe('db', () => {
         describe('.executeQuery', () => {
           beforeEach(() => Promise.all([
             dbConn.executeQuery(`
-              INSERT INTO users (username, email, password, createdat)
-              VALUES ('maxcnunes', 'maxcnunes@gmail.com', '123456', '2016-10-25')
-            `),
-            dbConn.executeQuery(`
               INSERT INTO roles (name)
               VALUES ('developer')
+            `),
+            dbConn.executeQuery(`
+              INSERT INTO users (username, email, password, role_id, createdat)
+              VALUES ('maxcnunes', 'maxcnunes@gmail.com', '123456', '1','2016-10-25')
             `),
           ]));
 
@@ -317,7 +325,9 @@ describe('db', () => {
               expect(result).to.have.deep.property('fields[1].name').to.eql('username');
               expect(result).to.have.deep.property('fields[2].name').to.eql('email');
               expect(result).to.have.deep.property('fields[3].name').to.eql('password');
-              expect(result).to.have.deep.property('fields[4].name').to.eql('createdat');
+              expect(result).to.have.deep.property('fields[4].name').to.eql('role_id');
+              expect(result).to.have.deep.property('fields[5].name').to.eql('createdat');
+
 
               expect(result).to.have.deep.property('rows[0].id').to.eql(1);
               expect(result).to.have.deep.property('rows[0].username').to.eql('maxcnunes');

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -152,6 +152,14 @@ describe('db', () => {
           });
         });
 
+        describe('.getTableReferences', () => {
+          it('should list all tables that selected table has references to', async() => {
+            const references = await dbConn.getTableReferences('users');
+            expect(references).to.have.length(1);
+            expect(references).to.include.members(['roles']);
+          });
+        });
+
         describe('.getTableCreateScript', () => {
           it('should return table create script', async() => {
             const [createScript] = await dbConn.getTableCreateScript('users');

--- a/src/db/client.js
+++ b/src/db/client.js
@@ -22,6 +22,7 @@ export function createConnection(server, database) {
     listRoutines: listRoutines.bind(null, server, database),
     listTableColumns: listTableColumns.bind(null, server, database),
     listTableTriggers: listTableTriggers.bind(null, server, database),
+    getTableReferences: getTableReferences.bind(null, server, database),
     executeQuery: executeQuery.bind(null, server, database),
     listDatabases: listDatabases.bind(null, server, database),
     getQuerySelectTop: getQuerySelectTop.bind(null, server, database),
@@ -136,6 +137,11 @@ async function listTableColumns(server, database, table) {
 async function listTableTriggers(server, database, table) {
   checkIsConnected(server, database);
   return database.connection.listTableTriggers(table);
+}
+
+async function getTableReferences(server, database, table) {
+  checkIsConnected(server, database);
+  return database.connection.getTableReferences(table);
 }
 
 async function executeQuery(server, database, query) {

--- a/src/db/clients/mysql.js
+++ b/src/db/clients/mysql.js
@@ -34,6 +34,7 @@ export default function(server, database) {
         listRoutines: () => listRoutines(client),
         listTableColumns: (table) => listTableColumns(client, table),
         listTableTriggers: (table) => listTableTriggers(client, table),
+        getTableReferences: (table) => getTableReferences(client, table),
         executeQuery: (query) => executeQuery(client, query),
         listDatabases: () => listDatabases(client),
         getQuerySelectTop: (table, limit) => getQuerySelectTop(client, table, limit),
@@ -139,6 +140,25 @@ export function listTableTriggers(client, table) {
     client.query(sql, params, (err, data) => {
       if (err) return reject(_getRealError(client, err));
       resolve(data.map(row => row.trigger_name));
+    });
+  });
+}
+
+export function getTableReferences(client, table) {
+  return new Promise((resolve, reject) => {
+    const sql = `
+      SELECT referenced_table_name
+      FROM information_schema.key_column_usage
+      WHERE referenced_table_name IS NOT NULL
+      AND table_schema = database()
+      AND table_name = ?
+    `;
+    const params = [
+      table,
+    ];
+    client.query(sql, params, (err, data) => {
+      if (err) return reject(_getRealError(client, err));
+      resolve(data.map(row => row.referenced_table_name));
     });
   });
 }

--- a/src/db/clients/mysql.js
+++ b/src/db/clients/mysql.js
@@ -249,7 +249,9 @@ export const truncateAllTables = async (client) => {
   const [result] = await executeQuery(client, sql);
   const tables = result.rows.map(row => row.table_name);
   const promises = tables.map(t => executeQuery(client, `
-    TRUNCATE TABLE ${wrapQuery(schema)}.${wrapQuery(t)}
+    SET FOREIGN_KEY_CHECKS = 0;
+    TRUNCATE TABLE ${wrapQuery(schema)}.${wrapQuery(t)};
+    SET FOREIGN_KEY_CHECKS = 1;
   `));
 
   await Promise.all(promises);

--- a/src/db/clients/sqlserver.js
+++ b/src/db/clients/sqlserver.js
@@ -24,6 +24,7 @@ export default async function(server, database) {
       listRoutines: () => listRoutines(connection),
       listTableColumns: (table) => listTableColumns(connection, table),
       listTableTriggers: (table) => listTableTriggers(connection, table),
+      getTableReferences: (table) => getTableReferences(connection, table),
       executeQuery: (query) => executeQuery(connection, query),
       listDatabases: () => listDatabases(connection),
       getQuerySelectTop: (table, limit) => getQuerySelectTop(connection, table, limit),
@@ -128,6 +129,16 @@ export const listTableTriggers = async (connection, table) => {
 export const listDatabases = async (connection) => {
   const [result] = await executeQuery(connection, 'SELECT name FROM sys.databases');
   return result.rows.map(row => row.name);
+};
+
+export const getTableReferences = async (connection, table) => {
+  const sql = `
+    SELECT OBJECT_NAME(referenced_object_id) referenced_table_name
+    FROM sys.foreign_keys
+    WHERE parent_object_id = OBJECT_ID('${table}')
+  `;
+  const [result] = await executeQuery(connection, sql);
+  return result.rows.map(row => row.referenced_table_name);
 };
 
 export const getTableCreateScript = async (connection, table) => {

--- a/src/db/clients/sqlserver.js
+++ b/src/db/clients/sqlserver.js
@@ -237,7 +237,8 @@ export const truncateAllTables = async (connection) => {
   const [result] = await executeQuery(connection, sql);
   const tables = result.rows.map(row => row.table_name);
   const promises = tables.map(t => executeQuery(connection, `
-    TRUNCATE TABLE ${wrapQuery(schema)}.${wrapQuery(t)}
+    DELETE FROM ${wrapQuery(schema)}.${wrapQuery(t)}
+    DBCC CHECKIDENT ('${schema}.${t}', RESEED, 0)
   `));
 
   await Promise.all(promises);


### PR DESCRIPTION
Addition in API needed for implementing [database diagram feature](https://github.com/sqlectron/sqlectron-gui/issues/165).

Had to do minor changes on `truncateAllTables` method. Since `TRUNCATE TABLE` does not work on MySQL and SQL Server when table has foreign key references, I did it another way around. It should work the same. Especially since we use it only for development purposes. 

Also, I've compiled it and tried on aforementioned feature and it works fine. Haven't run tests only on SQL Server, but CI should do the work.

