### PR TITLE
feat: try to fix quoting for all databases.

### DIFF
--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -208,7 +208,9 @@ describe('db', () => {
             const selectQuery = await dbConn.getTableSelectScript('users');
             if (dbClient === 'mysql') {
               expect(selectQuery).to.eql('SELECT id, username, email, password, role_id, createdat FROM `users`;');
-            } else { // sqlserver or postgresql
+            } else if (dbClient === 'sqlserver') {
+              expect(selectQuery).to.eql('SELECT id, username, email, password, role_id, createdat FROM [users];');
+            } else { // postgresql
               expect(selectQuery).to.eql('SELECT id, username, email, password, role_id, createdat FROM "users";');
             }
           });
@@ -220,7 +222,9 @@ describe('db', () => {
             const insertQuery = await dbConn.getTableInsertScript('users');
             if (dbClient === 'mysql') {
               expect(insertQuery).to.eql(`INSERT INTO \`users\` (id, username, email, password, role_id, createdat)\n VALUES (?, ?, ?, ?, ?, ?);`);
-            } else { // sqlserver or postgresql
+            } else if (dbClient === 'sqlserver') {
+              expect(insertQuery).to.eql(`INSERT INTO [users] (id, username, email, password, role_id, createdat)\n VALUES (?, ?, ?, ?, ?, ?);`);
+            } else { // postgresql
               expect(insertQuery).to.eql(`INSERT INTO "users" (id, username, email, password, role_id, createdat)\n VALUES (?, ?, ?, ?, ?, ?);`);
             }
           });
@@ -231,7 +235,9 @@ describe('db', () => {
             const updateQuery = await dbConn.getTableUpdateScript('users');
             if (dbClient === 'mysql') {
               expect(updateQuery).to.eql(`UPDATE \`users\`\n   SET id=?, username=?, email=?, password=?, role_id=?, createdat=?\n WHERE <condition>;`);
-            } else { // sqlserver or postgresql
+            } else if (dbClient === 'sqlserver') {
+              expect(updateQuery).to.eql(`UPDATE [users]\n   SET id=?, username=?, email=?, password=?, role_id=?, createdat=?\n WHERE <condition>;`);
+            } else { // postgresql
               expect(updateQuery).to.eql(`UPDATE "users"\n   SET id=?, username=?, email=?, password=?, role_id=?, createdat=?\n WHERE <condition>;`);
             }
           });
@@ -242,7 +248,9 @@ describe('db', () => {
             const deleteQuery = await dbConn.getTableDeleteScript('roles');
             if (dbClient === 'mysql') {
               expect(deleteQuery).to.contain('DELETE FROM `roles` WHERE <condition>;');
-            } else { // sqlserver or postgresql
+            } else if (dbClient === 'sqlserver') {
+              expect(deleteQuery).to.contain('DELETE FROM [roles] WHERE <condition>;');
+            } else { // postgresql
               expect(deleteQuery).to.contain('DELETE FROM "roles" WHERE <condition>;');
             }
           });

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -206,7 +206,11 @@ describe('db', () => {
         describe('.getTableSelectScript', () => {
           it('should return SELECT table script', async() => {
             const selectQuery = await dbConn.getTableSelectScript('users');
-            expect(selectQuery).to.eql('SELECT id, username, email, password, role_id, createdat FROM users;');
+            if (dbClient === 'mysql') {
+              expect(selectQuery).to.eql('SELECT id, username, email, password, role_id, createdat FROM `users`;');
+            } else { // sqlserver or postgresql
+              expect(selectQuery).to.eql('SELECT id, username, email, password, role_id, createdat FROM "users";');
+            }
           });
         });
 
@@ -214,21 +218,33 @@ describe('db', () => {
         describe('.getTableInsertScript', () => {
           it('should return INSERT INTO table script', async() => {
             const insertQuery = await dbConn.getTableInsertScript('users');
-            expect(insertQuery).to.eql(`INSERT INTO users (id, username, email, password, role_id, createdat)\n VALUES (?, ?, ?, ?, ?, ?);`);
+            if (dbClient === 'mysql') {
+              expect(insertQuery).to.eql(`INSERT INTO \`users\` (id, username, email, password, role_id, createdat)\n VALUES (?, ?, ?, ?, ?, ?);`);
+            } else { // sqlserver or postgresql
+              expect(insertQuery).to.eql(`INSERT INTO "users" (id, username, email, password, role_id, createdat)\n VALUES (?, ?, ?, ?, ?, ?);`);
+            }
           });
         });
 
         describe('.getTableUpdateScript', () => {
           it('should return UPDATE table script', async() => {
             const updateQuery = await dbConn.getTableUpdateScript('users');
-            expect(updateQuery).to.eql(`UPDATE users\n   SET id=?, username=?, email=?, password=?, role_id=?, createdat=?\n WHERE <condition>;`);
+            if (dbClient === 'mysql') {
+              expect(updateQuery).to.eql(`UPDATE \`users\`\n   SET id=?, username=?, email=?, password=?, role_id=?, createdat=?\n WHERE <condition>;`);
+            } else { // sqlserver or postgresql
+              expect(updateQuery).to.eql(`UPDATE "users"\n   SET id=?, username=?, email=?, password=?, role_id=?, createdat=?\n WHERE <condition>;`);
+            }
           });
         });
 
         describe('.getTableDeleteScript', () => {
           it('should return table DELETE script', async() => {
             const deleteQuery = await dbConn.getTableDeleteScript('roles');
-            expect(deleteQuery).to.eql('DELETE FROM roles WHERE <condition>;');
+            if (dbClient === 'mysql') {
+              expect(deleteQuery).to.contain('DELETE FROM `roles` WHERE <condition>;');
+            } else { // sqlserver or postgresql
+              expect(deleteQuery).to.contain('DELETE FROM "roles" WHERE <condition>;');
+            }
           });
         });
 

--- a/src/db/client.js
+++ b/src/db/client.js
@@ -173,25 +173,25 @@ async function getTableCreateScript(server, database, table) {
 
 async function getTableSelectScript(server, database, table) {
   const columnNames = await getTableColumnNames(server, database, table);
-  return `SELECT ${columnNames.join(', ')} FROM ${table};`;
+  return `SELECT ${columnNames.join(', ')} FROM ${database.connection.wrapIdentifier(table)};`;
 }
 
 
 async function getTableInsertScript(server, database, table) {
   const columnNames = await getTableColumnNames(server, database, table);
-  return `INSERT INTO ${table} (${columnNames.join(', ')})\n VALUES (${columnNames.fill('?').join(', ')});`;
+  return `INSERT INTO ${database.connection.wrapIdentifier(table)} (${columnNames.join(', ')})\n VALUES (${columnNames.fill('?').join(', ')});`;
 }
 
 async function getTableUpdateScript(server, database, table) {
   const columnNames = await getTableColumnNames(server, database, table);
   const setColumnForm = columnNames.map(columnName => `${columnName}=?`).join(', ');
   const condition = '<condition>';
-  return `UPDATE ${table}\n   SET ${setColumnForm}\n WHERE ${condition};`;
+  return `UPDATE ${database.connection.wrapIdentifier(table)}\n   SET ${setColumnForm}\n WHERE ${condition};`;
 }
 
 async function getTableDeleteScript(server, database, table) {
   const condition = '<condition>';
-  return `DELETE FROM ${table} WHERE ${condition};`;
+  return `DELETE FROM ${database.connection.wrapIdentifier(table)} WHERE ${condition};`;
 }
 
 async function getViewCreateScript(server, database, view) {

--- a/src/db/clients/mysql.js
+++ b/src/db/clients/mysql.js
@@ -28,6 +28,7 @@ export default function(server, database) {
 
       debug('connected');
       resolve({
+        wrapIdentifier,
         disconnect: () => disconnect(client),
         listTables: () => listTables(client),
         listViews: () => listViews(client),
@@ -194,7 +195,7 @@ export function listDatabases(client) {
 
 
 export function getQuerySelectTop(client, table, limit) {
-  return `SELECT * FROM ${wrapQuery(table)} LIMIT ${limit}`;
+  return `SELECT * FROM ${wrapIdentifier(table)} LIMIT ${limit}`;
 }
 
 export function getTableCreateScript(client, table) {
@@ -229,8 +230,8 @@ export function getRoutineCreateScript(client, routine, type) {
   });
 }
 
-export function wrapQuery(item) {
-  return `\`${item}\``;
+export function wrapIdentifier(value) {
+  return (value !== '*' ? `\`${value.replace(/`/g, '``')}\`` : '*');
 }
 
 const getSchema = async (client) => {
@@ -250,7 +251,7 @@ export const truncateAllTables = async (client) => {
   const tables = result.rows.map(row => row.table_name);
   const promises = tables.map(t => executeQuery(client, `
     SET FOREIGN_KEY_CHECKS = 0;
-    TRUNCATE TABLE ${wrapQuery(schema)}.${wrapQuery(t)};
+    TRUNCATE TABLE ${wrapIdentifier(schema)}.${wrapIdentifier(t)};
     SET FOREIGN_KEY_CHECKS = 1;
   `));
 


### PR DESCRIPTION
Provide a quoting function (renamed from wrapQuery to WrapIdent)
and use it to generate insert/update/delete statements

the strategy is to quote every table names in generated queries.

![Quotes](https://media.giphy.com/media/3o7abDIKBIJNXtktJm/giphy.gif)

ps: there are still some issues with column quoting. but these are not handled by this PR.