### PR TITLE
Add getTableKeys method to the API

### DIFF
--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -163,18 +163,19 @@ describe('db', () => {
         describe('.getTableKeys', () => {
           it('should list all tables keys', async() => {
             const tableKeys = await dbConn.getTableKeys('users');
-            const [firstKey, secondKey] = tableKeys;
 
             expect(tableKeys).to.have.length(2);
 
-            if ( firstKey.keyType === 'PRIMARY KEY') {
-              expect(firstKey).to.have.property('columnName').to.eql('id');
-              expect(firstKey).to.have.property('referencedTable').to.be.a('null');
-            } else {
-              expect(secondKey).to.have.property('columnName').to.eql('role_id');
-              expect(secondKey).to.have.property('referencedTable').to.eql('roles');
-              expect(secondKey).to.have.property('keyType').to.eql('FOREIGN KEY');
-            }
+            tableKeys.map((key) => {
+              if ( key.keyType === 'PRIMARY KEY') {
+                expect(key).to.have.property('columnName').to.eql('id');
+                expect(key).to.have.property('referencedTable').to.be.a('null');
+              } else {
+                expect(key).to.have.property('columnName').to.eql('role_id');
+                expect(key).to.have.property('referencedTable').to.eql('roles');
+                expect(key).to.have.property('keyType').to.eql('FOREIGN KEY');
+              }
+            });
           });
         });
 

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -160,6 +160,23 @@ describe('db', () => {
           });
         });
 
+        describe('.getTableKeys', () => {
+          it('should list all tables keys', async() => {
+            const references = await dbConn.getTableKeys('users');
+            const [primaryKey, foreignKey] = references;
+
+            expect(references).to.have.length(2);
+
+            expect(primaryKey).to.have.property('columnName').to.eql('id');
+            expect(primaryKey).to.have.property('referencedTable').to.be.a('null');
+            expect(primaryKey).to.have.property('keyType').to.eql('PRIMARY KEY');
+
+            expect(foreignKey).to.have.property('columnName').to.eql('role_id');
+            expect(foreignKey).to.have.property('referencedTable').to.eql('roles');
+            expect(foreignKey).to.have.property('keyType').to.eql('FOREIGN KEY');
+          });
+        });
+
         describe('.getTableCreateScript', () => {
           it('should return table create script', async() => {
             const [createScript] = await dbConn.getTableCreateScript('users');

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -162,18 +162,19 @@ describe('db', () => {
 
         describe('.getTableKeys', () => {
           it('should list all tables keys', async() => {
-            const references = await dbConn.getTableKeys('users');
-            const [primaryKey, foreignKey] = references;
+            const tableKeys = await dbConn.getTableKeys('users');
+            const [firstKey, secondKey] = tableKeys;
 
-            expect(references).to.have.length(2);
+            expect(tableKeys).to.have.length(2);
 
-            expect(primaryKey).to.have.property('columnName').to.eql('id');
-            expect(primaryKey).to.have.property('referencedTable').to.be.a('null');
-            expect(primaryKey).to.have.property('keyType').to.eql('PRIMARY KEY');
-
-            expect(foreignKey).to.have.property('columnName').to.eql('role_id');
-            expect(foreignKey).to.have.property('referencedTable').to.eql('roles');
-            expect(foreignKey).to.have.property('keyType').to.eql('FOREIGN KEY');
+            if ( firstKey.keyType === 'PRIMARY KEY') {
+              expect(firstKey).to.have.property('columnName').to.eql('id');
+              expect(firstKey).to.have.property('referencedTable').to.be.a('null');
+            } else {
+              expect(secondKey).to.have.property('columnName').to.eql('role_id');
+              expect(secondKey).to.have.property('referencedTable').to.eql('roles');
+              expect(secondKey).to.have.property('keyType').to.eql('FOREIGN KEY');
+            }
           });
         });
 

--- a/src/db/client.js
+++ b/src/db/client.js
@@ -23,6 +23,7 @@ export function createConnection(server, database) {
     listTableColumns: listTableColumns.bind(null, server, database),
     listTableTriggers: listTableTriggers.bind(null, server, database),
     getTableReferences: getTableReferences.bind(null, server, database),
+    getTableKeys: getTableKeys.bind(null, server, database),
     executeQuery: executeQuery.bind(null, server, database),
     listDatabases: listDatabases.bind(null, server, database),
     getQuerySelectTop: getQuerySelectTop.bind(null, server, database),
@@ -142,6 +143,11 @@ async function listTableTriggers(server, database, table) {
 async function getTableReferences(server, database, table) {
   checkIsConnected(server, database);
   return database.connection.getTableReferences(table);
+}
+
+async function getTableKeys(server, database, table) {
+  checkIsConnected(server, database);
+  return database.connection.getTableKeys(table);
 }
 
 async function executeQuery(server, database, query) {

--- a/src/db/clients/sqlserver.js
+++ b/src/db/clients/sqlserver.js
@@ -148,15 +148,15 @@ export const getTableKeys = async (connection, table) => {
     SELECT
       tc.constraint_name,
     	kcu.column_name,
-    	CASE WHEN tc.constraint_type LIKE '%FOREIGN%' THEN ctu.table_name
+    	CASE WHEN tc.constraint_type LIKE '%FOREIGN%' THEN OBJECT_NAME(sfk.referenced_object_id)
     	ELSE NULL
     	END AS referenced_table_name,
     	tc.constraint_type
   	FROM information_schema.table_constraints AS tc
   	JOIN information_schema.key_column_usage AS kcu
     	ON tc.constraint_name = kcu.constraint_name
-  	JOIN information_schema.constraint_table_usage as ctu
-    	ON tc.constraint_name = ctu.constraint_name
+  	JOIN sys.foreign_keys as sfk
+    	ON sfk.parent_object_id = OBJECT_ID(tc.table_name)
   	WHERE tc.table_name = '${table}'
   	AND tc.constraint_type IN ('PRIMARY KEY', 'FOREIGN KEY')
   `;

--- a/src/db/clients/sqlserver.js
+++ b/src/db/clients/sqlserver.js
@@ -26,6 +26,7 @@ export default async function(server, database) {
       listTableColumns: (table) => listTableColumns(connection, table),
       listTableTriggers: (table) => listTableTriggers(connection, table),
       getTableReferences: (table) => getTableReferences(connection, table),
+      getTableKeys: (table) => getTableKeys(connection, table),
       executeQuery: (query) => executeQuery(connection, query),
       listDatabases: () => listDatabases(connection),
       getQuerySelectTop: (table, limit) => getQuerySelectTop(connection, table, limit),
@@ -140,6 +141,32 @@ export const getTableReferences = async (connection, table) => {
   `;
   const [result] = await executeQuery(connection, sql);
   return result.rows.map(row => row.referenced_table_name);
+};
+
+export const getTableKeys = async (connection, table) => {
+  const sql = `
+    SELECT
+      tc.constraint_name,
+    	kcu.column_name,
+    	CASE WHEN tc.constraint_type LIKE '%FOREIGN%' THEN ctu.table_name
+    	ELSE NULL
+    	END AS referenced_table_name,
+    	tc.constraint_type
+  	FROM information_schema.table_constraints AS tc
+  	JOIN information_schema.key_column_usage AS kcu
+    	ON tc.constraint_name = kcu.constraint_name
+  	JOIN information_schema.constraint_table_usage as ctu
+    	ON tc.constraint_name = ctu.constraint_name
+  	WHERE tc.table_name = '${table}'
+  	AND tc.constraint_type IN ('PRIMARY KEY', 'FOREIGN KEY')
+  `;
+  const [result] = await executeQuery(connection, sql);
+  return result.rows.map(row => ({
+    constraintName: row.constraint_name,
+    columnName: row.column_name,
+    referencedTable: row.referenced_table_name,
+    keyType: row.constraint_type,
+  }));
 };
 
 export const getTableCreateScript = async (connection, table) => {


### PR DESCRIPTION
Resolves #24 

Added method for fetching table primary and foreign keys. If it is a foreign key, it also returns referenced table name.

Since I kept `getTableReferences` method (maybe it can be used in some other use cases), new release requires only minor digit change :)