### PR TITLE
feat: first support of schema in other functions. Postgres only for now.

### DIFF
--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -240,7 +240,7 @@ describe('db', () => {
                 '  CONSTRAINT `users_ibfk_1` FOREIGN KEY (`role_id`) REFERENCES `roles` (`id`) ON DELETE CASCADE\n' +
               ') ENGINE=InnoDB');
             } else if (dbClient === 'postgresql') {
-              expect(createScript).to.eql('CREATE TABLE users (\n' +
+              expect(createScript).to.eql('CREATE TABLE public.users (\n' +
                 '  id integer NOT NULL,\n' +
                 '  username text NOT NULL,\n' +
                 '  email text NOT NULL,\n' +
@@ -346,7 +346,7 @@ describe('db', () => {
             if (dbClient === 'mysql') {
               expect(createScript).to.contain('VIEW `email_view` AS select `users`.`email` AS `email`,`users`.`password` AS `password` from `users`');
             } else if (dbClient === 'postgresql') {
-              expect(createScript).to.eql(`CREATE OR REPLACE VIEW email_view AS\n SELECT users.email,\n    users.password\n   FROM users;`);
+              expect(createScript).to.eql(`CREATE OR REPLACE VIEW "public".email_view AS\n SELECT users.email,\n    users.password\n   FROM users;`);
             } else if (dbClient === 'sqlserver') {
               expect(createScript).to.eql(`\nCREATE VIEW dbo.email_view AS\nSELECT dbo.users.email, dbo.users.password\nFROM dbo.users;\n`);
             } else if (dbClient === 'cassandra') {

--- a/src/db/client.js
+++ b/src/db/client.js
@@ -116,9 +116,9 @@ function disconnect(server, database) {
 }
 
 
-async function listTables(server, database) {
+async function listTables(server, database, schema) {
   checkIsConnected(server, database);
-  return database.connection.listTables(database.database);
+  return database.connection.listTables(database.database, schema);
 }
 
 function listSchemas(server, database) {
@@ -126,34 +126,34 @@ function listSchemas(server, database) {
   return database.connection.listSchemas(database.database);
 }
 
-async function listViews(server, database) {
+async function listViews(server, database, schema) {
   checkIsConnected(server, database);
-  return database.connection.listViews();
+  return database.connection.listViews(schema);
 }
 
-async function listRoutines(server, database) {
+async function listRoutines(server, database, schema) {
   checkIsConnected(server, database);
-  return database.connection.listRoutines();
+  return database.connection.listRoutines(schema);
 }
 
-async function listTableColumns(server, database, table) {
+async function listTableColumns(server, database, table, schema) {
   checkIsConnected(server, database);
-  return database.connection.listTableColumns(database.database, table);
+  return database.connection.listTableColumns(database.database, table, schema);
 }
 
-async function listTableTriggers(server, database, table) {
+async function listTableTriggers(server, database, table, schema) {
   checkIsConnected(server, database);
-  return database.connection.listTableTriggers(table);
+  return database.connection.listTableTriggers(table, schema);
 }
 
-async function getTableReferences(server, database, table) {
+async function getTableReferences(server, database, table, schema) {
   checkIsConnected(server, database);
-  return database.connection.getTableReferences(table);
+  return database.connection.getTableReferences(table, schema);
 }
 
-async function getTableKeys(server, database, table) {
+async function getTableKeys(server, database, table, schema) {
   checkIsConnected(server, database);
-  return database.connection.getTableKeys(database.database, table);
+  return database.connection.getTableKeys(database.database, table, schema);
 }
 
 async function executeQuery(server, database, query) {
@@ -168,7 +168,7 @@ async function listDatabases(server, database) {
 }
 
 
-async function getQuerySelectTop(server, database, table, limit) {
+async function getQuerySelectTop(server, database, table, schema, limit) {
   checkIsConnected(server, database);
   let _limit = limit;
   if (typeof _limit === 'undefined') {
@@ -178,51 +178,51 @@ async function getQuerySelectTop(server, database, table, limit) {
   return database.connection.getQuerySelectTop(table, _limit);
 }
 
-async function getTableCreateScript(server, database, table) {
+async function getTableCreateScript(server, database, table, schema) {
   checkIsConnected(server, database);
-  return database.connection.getTableCreateScript(table);
+  return database.connection.getTableCreateScript(table, schema);
 }
 
-async function getTableSelectScript(server, database, table) {
-  const columnNames = await getTableColumnNames(server, database, table);
+async function getTableSelectScript(server, database, table, schema) {
+  const columnNames = await getTableColumnNames(server, database, table, schema);
   return `SELECT ${columnNames.join(', ')} FROM ${database.connection.wrapIdentifier(table)};`;
 }
 
 
-async function getTableInsertScript(server, database, table) {
-  const columnNames = await getTableColumnNames(server, database, table);
+async function getTableInsertScript(server, database, table, schema) {
+  const columnNames = await getTableColumnNames(server, database, table, schema);
   return `INSERT INTO ${database.connection.wrapIdentifier(table)} (${columnNames.join(', ')})\n VALUES (${columnNames.fill('?').join(', ')});`;
 }
 
-async function getTableUpdateScript(server, database, table) {
-  const columnNames = await getTableColumnNames(server, database, table);
+async function getTableUpdateScript(server, database, table, schema) {
+  const columnNames = await getTableColumnNames(server, database, table, schema);
   const setColumnForm = columnNames.map(columnName => `${columnName}=?`).join(', ');
   const condition = '<condition>';
   return `UPDATE ${database.connection.wrapIdentifier(table)}\n   SET ${setColumnForm}\n WHERE ${condition};`;
 }
 
-async function getTableDeleteScript(server, database, table) {
+async function getTableDeleteScript(server, database, table /* , schema */) {
   const condition = '<condition>';
   return `DELETE FROM ${database.connection.wrapIdentifier(table)} WHERE ${condition};`;
 }
 
-async function getViewCreateScript(server, database, view) {
+async function getViewCreateScript(server, database, view /* , schema */) {
   checkIsConnected(server, database);
   return database.connection.getViewCreateScript(view);
 }
 
-async function getRoutineCreateScript(server, database, routine, type) {
+async function getRoutineCreateScript(server, database, routine, type, schema) {
   checkIsConnected(server, database);
-  return database.connection.getRoutineCreateScript(routine, type);
+  return database.connection.getRoutineCreateScript(routine, type, schema);
 }
 
-function truncateAllTables(server, database) {
-  return database.connection.truncateAllTables(database.database);
+function truncateAllTables(server, database, schema) {
+  return database.connection.truncateAllTables(database.database, schema);
 }
 
-async function getTableColumnNames(server, database, table) {
+async function getTableColumnNames(server, database, table, schema) {
   checkIsConnected(server, database);
-  const columns = await database.connection.listTableColumns(database.database, table);
+  const columns = await database.connection.listTableColumns(database.database, table, schema);
   return columns.map(column => column.columnName);
 }
 


### PR DESCRIPTION
Following #29, here is the support of schemas in other functions of the databases.
Only 2 supported databases (Postgresql and sqlserver ) have support of schema.

but i'm not able to test over sqlserver so help is needed to add support there..

Please let me know what you think.
related to #28