### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,11 +33,11 @@
     "debug": "^2.2.0",
     "mssql": "^3.0.0",
     "mysql": "^2.10.2",
-    "node-uuid": "^1.4.3",
     "pg": "git+https://github.com/maxcnunes/node-postgres.git#multiple-statements-v6.1.0",
     "portfinder": "^0.4.0",
     "sql-query-identifier": "^1.0.0",
     "ssh2": "^0.5.0",
+    "uuid": "^3.0.0",
     "valida": "^2.0.0"
   },
   "devDependencies": {

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
-import uuid from 'node-uuid';
+import uuid from 'uuid';
 import { getConfigPath, writeJSONFile, readJSONFile, fileExists } from './utils';
 
 

--- a/src/servers.js
+++ b/src/servers.js
@@ -1,4 +1,4 @@
-import uuid from 'node-uuid';
+import uuid from 'uuid';
 import { validate, validateUniqueId } from './validators/server';
 import * as config from './config';
 


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.