### PR TITLE
Save ciphered db passwords instead of plain text

### DIFF
--- a/spec/config.spec.js
+++ b/spec/config.spec.js
@@ -18,6 +18,16 @@ describe('config', () => {
       expect(findItem(fixtureBefore)).to.not.have.property('id');
       expect(findItem(fixtureAfter)).to.have.property('id');
     });
+
+    it('should include hashedPwd = true for all servers', async () => {
+      await config.prepare();
+      const fixtureAfter = await loadConfig();
+
+      const hashedPwdCount =
+        fixtureAfter.servers.reduce((previous, curr) => previous + (curr.hashedPwd ? 1 : 0), 0);
+
+      expect(hashedPwdCount).to.equal(fixtureAfter.servers.length);
+    });
   });
 
   function loadConfig() {

--- a/spec/servers.spec.js
+++ b/spec/servers.spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { servers } from '../src';
-import { readJSONFile } from './../src/utils';
+import { readJSONFile, encryptString } from './../src/utils';
 import utilsStub from './utils-stub';
 
 
@@ -85,8 +85,11 @@ describe('servers', () => {
       expect(updatedServer).to.eql(serverToUpdate);
 
       const configAfter = await loadConfig();
+      const hashedServerToUpdate = { ...serverToUpdate };
+      hashedServerToUpdate.hashedPwd = true;
+      hashedServerToUpdate.password = encryptString(serverToUpdate.password);
       expect(configAfter.servers.length).to.eql(configBefore.servers.length);
-      expect(configAfter.servers.find((srv) => srv.id === id)).to.eql(serverToUpdate);
+      expect(configAfter.servers.find((srv) => srv.id === id)).to.eql(hashedServerToUpdate);
     });
   });
 
@@ -133,8 +136,11 @@ describe('servers', () => {
         expect(updatedServer).to.eql(serverToUpdate);
 
         const configAfter = await loadConfig();
+        const hashedServerToUpdate = { ...serverToUpdate };
+        hashedServerToUpdate.hashedPwd = true;
+        hashedServerToUpdate.password = encryptString(serverToUpdate.password);
         expect(configAfter.servers.length).to.eql(configBefore.servers.length);
-        expect(configAfter.servers.find((srv) => srv.id === id)).to.eql(serverToUpdate);
+        expect(configAfter.servers.find((srv) => srv.id === id)).to.eql(hashedServerToUpdate);
       });
     });
   });

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import pf from 'portfinder';
+import crypto from 'crypto';
 
 
 export function getConfigPath() {
@@ -121,4 +122,16 @@ export function createCancelablePromise(error, timeIdle = 100) {
       discarded = true;
     },
   };
+}
+
+
+export function encryptString(str) {
+  const cipher = crypto.createCipher('aes192', 'sqlectron');
+  return cipher.update(str, 'utf8', 'hex') + cipher.final('hex');
+}
+
+
+export function decryptString(str) {
+  const decipher = crypto.createDecipher('aes192', 'sqlectron');
+  return decipher.update(str, 'hex', 'utf8') + decipher.final('utf8');
 }


### PR DESCRIPTION
Following issue #39, I created this PR since the fact that the passwords are saved as plain text is not really nice for me.

The idea of the PR is to add simple methods to cipher/decipher the password in the utils file and use them in the get/getSync/save/sanitizeServers. I also added the field hashedPwd to know if the password should be decrypted/encrypted. This way backwards compatibility is maintained.

Even thought this approach is not secure enough (maybe using keychain, https://github.com/atom/node-keytar, would be a better solution), it is a good start.

Let me know if you like the approach.