### PR TITLE
Allow use the right common path for configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ $ npm install sqlectron-core --save
 
 ## Configuration
 
-SQLECTRON keeps a hidden configuration file called `.sqlectron.json` at the user's home directory (`~/` osx and linux; `%userprofile%` windows ).
+SQLECTRON keeps a configuration file in the directory
+
+* **MacOS:** `~/Library/Preferences/Sqlectron`
+* **Linux** (`$XDG_CONFIG_HOME` or `~/.config`) + `/Sqlectron`
+* **Windows** (`$LOCALAPPDATA` or `%USERPROFILE%\AppData\Local`) + `\Sqlectron\Config`
+
+> For older versions it was stored as `.sqlectron.json` at the user's home directory (`~/` osx and linux; `%userprofile%` windows ).
 
 Although you can change this file manually, most of time you should not worry about it because SQLECTRON will manage the configuration for you.
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
   "dependencies": {
     "cassandra-driver": "^3.1.1",
     "debug": "^2.2.0",
+    "env-paths": "^1.0.0",
+    "mkdirp": "^0.5.1",
     "mssql": "^3.0.0",
     "mysql": "^2.10.2",
     "pg": "git+https://github.com/maxcnunes/node-postgres.git#multiple-statements-v6.1.0",

--- a/src/config.js
+++ b/src/config.js
@@ -41,6 +41,7 @@ export async function prepare(cryptoSecret) {
   const filename = utils.getConfigPath();
   const fileExistsResult = await utils.fileExists(filename);
   if (!fileExistsResult) {
+    await utils.createParentDirectory(filename);
     await utils.writeJSONFile(filename, EMPTY_CONFIG);
   }
 
@@ -60,6 +61,7 @@ export function prepareSync(cryptoSecret) {
   const filename = utils.getConfigPath();
   const fileExistsResult = utils.fileExistsSync(filename);
   if (!fileExistsResult) {
+    utils.createParentDirectorySync(filename);
     utils.writeJSONFileSync(filename, EMPTY_CONFIG);
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,10 +1,27 @@
 import fs from 'fs';
 import path from 'path';
+import mkdirp from 'mkdirp';
 import pf from 'portfinder';
+import envPaths from 'env-paths';
 
+let configPath = '';
 
 export function getConfigPath() {
-  return path.join(homedir(), '.sqlectron.json');
+  if (configPath) {
+    return configPath;
+  }
+
+  const configName = 'sqlectron.json';
+  const oldConfigPath = path.join(homedir(), `.${configName}`);
+
+  if (fileExistsSync(oldConfigPath)) {
+    configPath = oldConfigPath;
+  } else {
+    const newConfigDir = envPaths('Sqlectron', { suffix: '' }).config;
+    configPath = path.join(newConfigDir, configName);
+  }
+
+  return configPath;
 }
 
 
@@ -72,6 +89,16 @@ export function readJSONFileSync(filename) {
   const filePath = resolveHomePathToAbsolute(filename);
   const data = fs.readFileSync(path.resolve(filePath), { enconding: 'utf-8' });
   return JSON.parse(data);
+}
+
+export function createParentDirectory(filename) {
+  return new Promise((resolve, reject) =>
+    (mkdirp(path.dirname(filename), (err) => (err ? reject(err) : resolve())))
+  );
+}
+
+export function createParentDirectorySync(filename) {
+  mkdirp.sync(path.dirname(filename));
 }
 
 


### PR DESCRIPTION
It will use the old path if the user still have the file in that path.
But if the user has moved the configuration file for the new directory then it will read from there.

Close #46