### PR TITLE
Supporting Cassandra 2.x

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,12 @@ environment:
   # While that is not configured we do not
   # run automated test for cassandra client
   CASSANDRA_PORT: tcp://localhost:9042
+
+  # Disabling Cassandra 2.x testing by default, as a Cassandra 2.x container
+  # take minutes to start and will likely fail on CI.
+  ENABLE_CASSANDRA2X_TEST: 0
+  CASSANDRA2X_PORT: tcp://cassandra2x:9042
+
   DB_CLIENTS: mysql,postgresql,sqlserver,sqlite
   # postgres
   POSTGRES_PORT: tcp://localhost:5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,14 @@ cassandra:
     - 7000 # cluster
     - 9042 # native
 
+cassandra2x:
+  image: cassandra:2.1
+  environment:
+    JVM_OPTS: -Xms128m -Xmx512m
+  ports:
+    - 7000 # cluster
+    - 9042 # native
+
 test:
   image: node:6.5.0-onbuild
   command: npm test
@@ -40,3 +48,4 @@ test:
     - mysql:mysql
     - postgres:postgres
     - cassandra:cassandra
+    - cassandra2x:cassandra2x

--- a/spec/databases/config.js
+++ b/spec/databases/config.js
@@ -32,4 +32,9 @@ export default {
     port: 9042,
     database: 'sqlectron',
   },
+  cassandra2x: {
+    host: url.parse(process.env.CASSANDRA2X_PORT || '').hostname,
+    port: 9042,
+    database: 'sqlectron',
+  },
 };

--- a/src/db/clients/cassandra.js
+++ b/src/db/clients/cassandra.js
@@ -56,18 +56,29 @@ export function disconnect(client) {
 
 
 export function listTables(client, database) {
-  return new Promise((resolve, reject) => {
-    const sql = `
-      SELECT table_name as name
-      FROM system_schema.tables
-      WHERE keyspace_name = ?
-    `;
-    const params = [database];
-    client.execute(sql, params, (err, data) => {
-      if (err) return reject(err);
-      resolve(data.rows.map((row) => ({ name: row.name })));
+  return isLegacyVersion(client)
+    .then((isLegacy) => {
+      if (isLegacy) {
+        // for Cassandra 2.x
+        return `SELECT columnfamily_name as name
+          FROM system.schema_columnfamilies
+          WHERE keyspace_name = ?
+        `;
+      }
+      return `SELECT table_name as name
+          FROM system_schema.tables
+          WHERE keyspace_name = ?
+        `;
+    })
+    .then((cql) => {
+      const params = [database];
+      return new Promise((resolve, reject) => {
+        client.execute(cql, params, (err, data) => {
+          if (err) reject(err);
+          resolve(data.rows.map((row) => ({ name: row.name })));
+        });
+      });
     });
-  });
 }
 
 export function listViews() {
@@ -79,30 +90,77 @@ export function listRoutines() {
 }
 
 export function listTableColumns(client, database, table) {
-  return new Promise((resolve, reject) => {
-    const sql = `
-      SELECT position, column_name, type
-      FROM system_schema.columns
-      WHERE keyspace_name = ?
-        AND table_name = ?
-    `;
-    const params = [
-      database,
-      table,
-    ];
-    client.execute(sql, params, (err, data) => {
-      if (err) return reject(err);
-      resolve(
-        data.rows
-        // force pks be placed at the results beginning
-        .sort((a, b) => b.position - a.position)
-        .map((row) => ({
-          columnName: row.column_name,
-          dataType: row.type,
-        }))
+  return isLegacyVersion(client)
+    .then((isLegacy) => {
+      const cqlText = isLegacy
+       ? `SELECT type as position, column_name, validator as type
+            FROM system.schema_columns
+            WHERE keyspace_name = ? AND columnfamily_name = ?`
+       : `SELECT position, column_name, type
+            FROM system_schema.columns
+            WHERE keyspace_name = ? AND table_name = ?`;
+      return { text: cqlText, isLegacy };
+    }).then((cql) => {
+      const params = [
+        database,
+        table,
+      ];
+      return new Promise((resolve, reject) =>
+        client.execute(cql.text, params, (err, data) => {
+          if (err) reject(err);
+          if (cql.isLegacy) { // Cassandra 2.x
+            resolve(data.rows
+              .sort((a, b) => +(a.position > b.position) || -(a.position < b.position))
+              .map((row) => ({
+                columnName: row.column_name,
+                dataType: mapLegacyDataTypes(row.type),
+              }))
+            );
+          } else {
+            resolve(data.rows
+              // force pks be placed at the results beginning
+              .sort((a, b) => b.position - a.position)
+              .map((row) => ({
+                columnName: row.column_name,
+                dataType: row.type,
+              }))
+            );
+          }
+        })
       );
     });
-  });
+}
+
+/**
+ * The system schema of Casandra 2.x does not have data type, but only validator
+ * classes. To make the behavior consistent with v3.x, we try to deduce the
+ * correponding CQL data type using the validator name.
+ * @param {string} validator
+ * @returns {string}
+ */
+function mapLegacyDataTypes(validator) {
+  const type = validator.split('.').pop();
+  switch (type) {
+    case 'Int32Type':
+    case 'LongType':
+      return 'int';
+    case 'UTF8Type':
+      return 'text';
+    case 'TimestampType':
+    case 'DateType':
+      return 'timestamp';
+    case 'DoubleType':
+      return 'double';
+    case 'FloatType':
+      return 'float';
+    case 'UUIDType':
+      return 'uuid';
+    case 'CounterColumnType':
+      return 'counter';
+    default:
+      logger().debug('validator %s is not yet mapped!', validator);
+      return type;
+  }
 }
 
 export function listTableTriggers() {
@@ -121,29 +179,17 @@ export function getTableReferences() {
 }
 
 export function getTableKeys(client, database, table) {
-  return new Promise((resolve, reject) => {
-    const sql = `
-      SELECT column_name
-      FROM system_schema.columns
-      WHERE keyspace_name = ?
-        AND table_name = ?
-        AND kind = 'partition_key'
-      ALLOW FILTERING
-    `;
-    const params = [
-      database,
-      table,
-    ];
-    client.execute(sql, params, (err, data) => {
-      if (err) return reject(err);
-      resolve(data.rows.map((row) => ({
+  return client.metadata
+    .getTable(database, table)
+    .then((tableInfo) => tableInfo
+      .partitionKeys
+      .map((key) => ({
         constraintName: null,
-        columnName: row.column_name,
+        columnName: key.name,
         referencedTable: null,
         keyType: 'PRIMARY KEY',
-      })));
-    });
-  });
+      }))
+    );
 }
 
 function query(conn, queryText) { // eslint-disable-line no-unused-vars
@@ -164,13 +210,8 @@ export function executeQuery(client, queryText) {
 
 
 export function listDatabases(client) {
-  return new Promise((resolve, reject) => {
-    const sql = 'SELECT keyspace_name FROM system_schema.keyspaces';
-    const params = [];
-    client.execute(sql, params, (err, data) => {
-      if (err) return reject(err);
-      resolve(data.rows.map((row) => row.keyspace_name));
-    });
+  return new Promise((resolve) => {
+    resolve(Object.keys(client.metadata.keyspaces));
   });
 }
 
@@ -200,13 +241,8 @@ export function wrapIdentifier(value) {
 
 
 export const truncateAllTables = async (connection, database) => {
-  const sql = `
-    SELECT table_name
-    FROM system_schema.tables
-    WHERE keyspace_name = '${database}'
-  `;
-  const [result] = await executeQuery(connection, sql);
-  const tables = result.rows.map((row) => row.table_name);
+  const result = await listTables(connection, database);
+  const tables = result.map((table) => table.name);
   const promises = tables.map((t) => {
     const truncateSQL = `
       TRUNCATE TABLE ${wrapIdentifier(database)}.${wrapIdentifier(t)};
@@ -238,6 +274,23 @@ function configDatabase(server, database) {
   return config;
 }
 
+/**
+ * Connects to the server cluster and determine if it is a legacy (<3.0) version
+ * @param {Client} client
+ * @returns {Promise<boolean>}
+ */
+function isLegacyVersion(client) {
+  return client.connect()
+    .then(() => {
+      let cassandraVersion = '3.0.0';
+      try {
+        cassandraVersion = client.getState().getConnectedHosts()[0].cassandraVersion;
+      } catch (err) {
+        logger().debug(err);
+      }
+      return cassandraVersion.split('.')[0] < '3';
+    });
+}
 
 function parseRowQueryResult(data, command) {
   // Fallback in case the identifier could not reconize the command


### PR DESCRIPTION
The Cassandra driver we use works with both Cassandra 2.x and 3.x, however, the system schemas are different. To make Sqlectron work with Cassandra 2.x, we need to send different metadata queries to older servers.

The approach in this PR is to use the metadata provided by the driver whenever possible (already implemented in the [schema parser](https://github.com/datastax/nodejs-driver/blob/ab065a6e193b00e7f57427a73a1cc4245790a6c5/lib/metadata/schema-parser.js#L17) from of the driver). Otherwise, we define two variants of the schema queries and send one corresponding to the server version.
