### PR TITLE
Bump sqlite3 to 4.0.2 so build succeeds with node 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "pg": "git+https://github.com/maxcnunes/node-postgres.git#multiple-statements-v6.1.0",
     "portfinder": "^0.4.0",
     "sql-query-identifier": "^1.1.0",
-    "sqlite3": "^3.1.8",
     "ssh2": "^0.5.0",
     "uuid": "^3.0.0",
     "valida": "^2.0.0"
@@ -61,6 +60,6 @@
     "eslint-plugin-import": "^1.15.0",
     "mocha": "^3.0.2",
     "sinon": "^1.17.2",
-    "sqlite3": "^3.1.0"
+    "sqlite3": "^4.0.2"
   }
 }


### PR DESCRIPTION
It's impossible to build sqlite3 on node>=10 due to [this](https://stackoverflow.com/a/50112270/4106215):

> The problem here is that V8 has removed ForceSet method in the V8 version that Node 10 uses, which in turn is what the nan module uses. nan has not yet caught up to the breaking changes in V8.