### PR TITLE
Fix for inability to create postgresql client with socket connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # sqlectron-core
 
+
 [![Build status](https://ci.appveyor.com/api/projects/status/bdnpb06lu4sl0hwn/branch/master?svg=true)](https://ci.appveyor.com/project/maxcnunes/sqlectron-core/branch/master)
 
 The common code used by all sqlectron clients.

--- a/src/validators/server.js
+++ b/src/validators/server.js
@@ -4,7 +4,15 @@ import { CLIENTS } from '../db';
 
 function serverAddressValidator(ctx) {
   const { host, port, socketPath } = ctx.obj;
-  if ((!host && !port && !socketPath) || ((host || port) && socketPath)) {
+
+  if(!host && !socketPath) {
+    return {
+      validator: 'serverAddressValidator',
+      msg: 'You must use host+port or socket path',
+    };
+  }
+
+  if(host && socketPath) {
     return {
       validator: 'serverAddressValidator',
       msg: 'You must use host+port or socket path',

--- a/src/validators/server.js
+++ b/src/validators/server.js
@@ -5,14 +5,8 @@ import { CLIENTS } from '../db';
 function serverAddressValidator(ctx) {
   const { host, port, socketPath } = ctx.obj;
 
-  if (!host && !socketPath) {
-    return {
-      validator: 'serverAddressValidator',
-      msg: 'You must use host+port or socket path',
-    };
-  }
-
-  if (host && socketPath) {
+  // we need either a host, or a socket path, but not both, and not neither.
+  if ((!host && !socketPath) || (host && socketPath)) {
     return {
       validator: 'serverAddressValidator',
       msg: 'You must use host+port or socket path',

--- a/src/validators/server.js
+++ b/src/validators/server.js
@@ -5,14 +5,14 @@ import { CLIENTS } from '../db';
 function serverAddressValidator(ctx) {
   const { host, port, socketPath } = ctx.obj;
 
-  if(!host && !socketPath) {
+  if (!host && !socketPath) {
     return {
       validator: 'serverAddressValidator',
       msg: 'You must use host+port or socket path',
     };
   }
 
-  if(host && socketPath) {
+  if (host && socketPath) {
     return {
       validator: 'serverAddressValidator',
       msg: 'You must use host+port or socket path',


### PR DESCRIPTION
Fixes https://github.com/sqlectron/sqlectron-gui/issues/432

There's a default port always set when creating a PSQL connection, the validator is over-aggressive in checking host/port and socketPath combos, this fixes that.
