### PR TITLE
use os.homedir to find user home directory

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { homedir } from 'os';
 import path from 'path';
 import mkdirp from 'mkdirp';
 import pf from 'portfinder';
@@ -22,11 +23,6 @@ export function getConfigPath() {
   }
 
   return configPath;
-}
-
-
-export function homedir() {
-  return process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'];
 }
 
 


### PR DESCRIPTION
The `os.homedir()` function has been available since node 2.3.0. Given the engine requires `node >= 6`, it's safe to replace the custom implementation with the stdlib one.