### PR TITLE
use ordinal_position to column list in pg, sqlsrv, mysql

### DIFF
--- a/src/db/clients/mysql.js
+++ b/src/db/clients/mysql.js
@@ -102,6 +102,7 @@ export async function listTableColumns(conn, database, table) {
     FROM information_schema.columns
     WHERE table_schema = database()
     AND table_name = ?
+    ORDER BY ordinal_position
   `;
 
   const params = [

--- a/src/db/clients/postgresql.js
+++ b/src/db/clients/postgresql.js
@@ -124,6 +124,7 @@ export async function listTableColumns(conn, database, table, schema) {
     FROM information_schema.columns
     WHERE table_schema = $1
     AND table_name = $2
+    ORDER BY ordinal_position
   `;
 
   const params = [

--- a/src/db/clients/sqlserver.js
+++ b/src/db/clients/sqlserver.js
@@ -191,6 +191,7 @@ export async function listTableColumns(conn, database, table) {
     SELECT column_name, data_type
     FROM information_schema.columns
     WHERE table_name = '${table}'
+    ORDER BY ordinal_position
   `;
 
   const { data } = await driverExecuteQuery(conn, { query: sql });


### PR DESCRIPTION
The `information_schema.columns` table contains a column `ordinal_position` that tells how the columns should be ordered for displaying. In theory, there's then nothing to mandate the order of rows within that table so it's possible you could have (and I've seen):

| column_name | data_type | ordinal_position |
|---------------|-----------|-----------------|
| column_2        | int              | 2                         |
| column_1         | int              | 1.                        |