### PR TITLE
update babel-eslint to ^7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -315,16 +315,15 @@
       }
     },
     "babel-eslint": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-6.1.2.tgz",
-      "integrity": "sha1-UpNBn+NnLWZZjTJ9qWlFZ7pqXy8=",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.3.tgz",
+      "integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
       "dev": true,
       "requires": {
-        "babel-traverse": "^6.0.20",
-        "babel-types": "^6.0.19",
-        "babylon": "^6.0.18",
-        "lodash.assign": "^4.0.0",
-        "lodash.pickby": "^4.0.0"
+        "babel-code-frame": "^6.22.0",
+        "babel-traverse": "^6.23.1",
+        "babel-types": "^6.23.0",
+        "babylon": "^6.17.0"
       }
     },
     "babel-generator": {
@@ -2476,12 +2475,6 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-      "dev": true
-    },
     "lodash.cond": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
@@ -2510,12 +2503,6 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-    },
-    "lodash.pickby": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
-      "integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8=",
-      "dev": true
     },
     "lolex": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",
-    "babel-eslint": "^6.1.2",
+    "babel-eslint": "^7.2.3",
     "babel-plugin-syntax-object-rest-spread": "^6.13.0",
     "babel-plugin-transform-async-to-generator": "^6.8.0",
     "babel-plugin-transform-es2015-destructuring": "^6.9.0",

--- a/spec/utils-stub.js
+++ b/spec/utils-stub.js
@@ -13,7 +13,7 @@ export default {
 
   getConfigPath: {
     install({ copyFixtureToTemp }) {
-      beforeEach(async function() {
+      beforeEach(async () => {
         if (copyFixtureToTemp) {
           const data = await utils.readJSONFile(FIXTURE_PATH);
           await utils.writeJSONFile(TMP_FIXTURE_PATH, data);


### PR DESCRIPTION
This is required to do to update eslint in #66. eslint 4 moved to using `eslint-scope` instead of `escope`, which babel-eslint 7.2.2 is setup to detect. Updating eslint without updating babel-eslint will cause an error of `escope` not being able to be found.