### PR TITLE
add function to get connected database version

### DIFF
--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -91,6 +91,13 @@ describe('db', () => {
           });
         });
 
+        describe('.version', () => {
+          it('should return a version', async () => {
+            expect(dbConn.version()).to.be.a('string');
+            expect(dbConn.version()).to.not.be.empty;
+          });
+        });
+
         describe('.listDatabases', () => {
           it('should list all databases', async () => {
             const databases = await dbConn.listDatabases();

--- a/src/db/client.js
+++ b/src/db/client.js
@@ -18,6 +18,7 @@ export function createConnection(server, database) {
   return {
     connect: connect.bind(null, server, database),
     disconnect: disconnect.bind(null, server, database),
+    version: version.bind(null, server, database),
     listTables: listTables.bind(null, server, database),
     listViews: listViews.bind(null, server, database),
     listRoutines: listRoutines.bind(null, server, database),
@@ -117,6 +118,11 @@ function disconnect(server, database) {
   if (server.db[database.database]) {
     delete server.db[database.database];
   }
+}
+
+function version(server, database) {
+  checkIsConnected(server, database);
+  return database.connection.version;
 }
 
 function listSchemas(server, database, filter) {

--- a/src/db/clients/cassandra.js
+++ b/src/db/clients/cassandra.js
@@ -17,38 +17,46 @@ export default function (server, database) {
     const client = new cassandra.Client(dbConfig);
 
     logger().debug('connecting');
-    client.connect((err) => {
+    client.connect(async (err) => {
       if (err) {
         client.shutdown();
         return reject(err);
       }
 
-      logger().debug('connected');
-      resolve({
-        wrapIdentifier,
-        disconnect: () => disconnect(client),
-        listTables: (db) => listTables(client, db),
-        listViews: () => listViews(client),
-        listRoutines: () => listRoutines(client),
-        listTableColumns: (db, table) => listTableColumns(client, db, table),
-        listTableTriggers: (table) => listTableTriggers(client, table),
-        listTableIndexes: (db, table) => listTableIndexes(client, table),
-        listSchemas: () => listSchemas(client),
-        getTableReferences: (table) => getTableReferences(client, table),
-        getTableKeys: (db, table) => getTableKeys(client, db, table),
-        query: (queryText) => executeQuery(client, queryText),
-        executeQuery: (queryText) => executeQuery(client, queryText),
-        listDatabases: () => listDatabases(client),
-        getQuerySelectTop: (table, limit) => getQuerySelectTop(client, table, limit),
-        getTableCreateScript: (table) => getTableCreateScript(client, table),
-        getViewCreateScript: (view) => getViewCreateScript(client, view),
-        getRoutineCreateScript: (routine) => getRoutineCreateScript(client, routine),
-        truncateAllTables: (db) => truncateAllTables(client, db),
+      client.execute('SELECT cql_version FROM system.local;', (error, data) => {
+        if (error) {
+          client.shutdown();
+          return reject(error);
+        }
+        const version = data.rows[0].cql_version;
+
+        logger().debug('connected');
+        resolve({
+          wrapIdentifier,
+          version,
+          disconnect: () => disconnect(client),
+          listTables: (db) => listTables(client, db),
+          listViews: () => listViews(client),
+          listRoutines: () => listRoutines(client),
+          listTableColumns: (db, table) => listTableColumns(client, db, table),
+          listTableTriggers: (table) => listTableTriggers(client, table),
+          listTableIndexes: (db, table) => listTableIndexes(client, table),
+          listSchemas: () => listSchemas(client),
+          getTableReferences: (table) => getTableReferences(client, table),
+          getTableKeys: (db, table) => getTableKeys(client, db, table),
+          query: (queryText) => executeQuery(client, queryText),
+          executeQuery: (queryText) => executeQuery(client, queryText),
+          listDatabases: () => listDatabases(client),
+          getQuerySelectTop: (table, limit) => getQuerySelectTop(client, table, limit),
+          getTableCreateScript: (table) => getTableCreateScript(client, table),
+          getViewCreateScript: (view) => getViewCreateScript(client, view),
+          getRoutineCreateScript: (routine) => getRoutineCreateScript(client, routine),
+          truncateAllTables: (db) => truncateAllTables(client, db),
+        });
       });
     });
   });
 }
-
 
 export function disconnect(client) {
   client.shutdown();

--- a/src/db/clients/mysql.js
+++ b/src/db/clients/mysql.js
@@ -22,10 +22,11 @@ export default async function (server, database) {
   };
 
   // light solution to test connection with with the server
-  await driverExecuteQuery(conn, { query: 'select version();' });
+  const version = (await driverExecuteQuery(conn, { query: 'select version() as version;' })).data[0].version;
 
   return {
     wrapIdentifier,
+    version,
     disconnect: () => disconnect(conn),
     listTables: () => listTables(conn),
     listViews: () => listViews(conn),

--- a/src/db/clients/postgresql.js
+++ b/src/db/clients/postgresql.js
@@ -514,7 +514,7 @@ function parseRowQueryResult(data, command) {
     rows: data.rows,
     fields: data.fields,
     rowCount: isSelect ? (data.rowCount || data.rows.length) : undefined,
-    affectedRows: !isSelect && !isNaN(data.rowCount) ? data.rowCount : undefined,
+    affectedRows: !isSelect && !isNaN(data.rowCount) && data.rowCount !== null ? data.rowCount : undefined,
   };
 }
 

--- a/src/db/clients/sqlite.js
+++ b/src/db/clients/sqlite.js
@@ -17,10 +17,11 @@ export default async function (server, database) {
   const conn = { dbConfig };
 
   // light solution to test connection with with the server
-  await driverExecuteQuery(conn, { query: 'SELECT sqlite_version()' });
+  const version = (await driverExecuteQuery(conn, { query: 'SELECT sqlite_version() as version' })).data[0].version;
 
   return {
     wrapIdentifier,
+    version,
     disconnect: () => disconnect(conn),
     listTables: () => listTables(conn),
     listViews: () => listViews(conn),

--- a/src/db/clients/sqlserver.js
+++ b/src/db/clients/sqlserver.js
@@ -18,10 +18,11 @@ export default async function (server, database) {
   const conn = { dbConfig };
 
   // light solution to test connection with with the server
-  await driverExecuteQuery(conn, { query: 'SELECT @@version' });
+  const version = (await driverExecuteQuery(conn, { query: 'SELECT @@version as \'version\'' })).data[0].version;
 
   return {
     wrapIdentifier,
+    version,
     disconnect: () => disconnect(conn),
     listTables: (db, filter) => listTables(conn, filter),
     listViews: (filter) => listViews(conn, filter),


### PR DESCRIPTION
Adds a new function `dbConn.version()` which returns the version of the database connection. While not sure if this is useful for downstream consumers, it is going to be necessary for dealing with #69, #78, and maybe #79.

For 3 of the clients (mysql, sqlserver, sqlite), this basically comes free as the version query was being executed anyway to test for the connection. I would consider the other two being relatively cheap as well and if nothing else, brings the start-up time similar to the to other three that were running the query.