### PR TITLE
replace valida dependency with valida2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -777,23 +777,6 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
-<<<<<<< HEAD
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true,
-          "optional": true
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true,
-          "optional": true
-=======
->>>>>>> master
         }
       }
     },
@@ -2436,31 +2419,6 @@
       "dev": true,
       "optional": true
     },
-<<<<<<< HEAD
-    "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "^1.0.0"
-=======
-    "is-float": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-float/-/is-float-1.0.0.tgz",
-      "integrity": "sha1-Tc9D0W22HfNYgDHv/oJ6P8hEgew=",
-      "requires": {
-        "minimist": "1.1.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
-          "integrity": "sha1-G8K8cWWM3KVxJHVoQ2NhWwtPaVs="
-        }
->>>>>>> master
-      }
-    },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -4050,23 +4008,6 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
-<<<<<<< HEAD
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true,
-          "optional": true
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true,
-          "optional": true
-=======
->>>>>>> master
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -903,7 +903,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true,
           "optional": true
         }
@@ -2405,21 +2406,6 @@
       "dev": true,
       "requires": {
         "number-is-nan": "^1.0.0"
-      }
-    },
-    "is-float": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-float/-/is-float-1.0.0.tgz",
-      "integrity": "sha1-Tc9D0W22HfNYgDHv/oJ6P8hEgew=",
-      "requires": {
-        "minimist": "1.1.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
-          "integrity": "sha1-G8K8cWWM3KVxJHVoQ2NhWwtPaVs="
-        }
       }
     },
     "is-fullwidth-code-point": {
@@ -4298,7 +4284,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true,
           "optional": true
         }
@@ -4677,9 +4664,9 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "titlecase": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/titlecase/-/titlecase-1.1.2.tgz",
-      "integrity": "sha1-eBE9EQgIa4MmMxoyR96o9aSeqFM="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/titlecase/-/titlecase-1.1.3.tgz",
+      "integrity": "sha512-pQX4oiemzjBEELPqgK4WE+q0yhAqjp/yzusGtlSJsOuiDys0RQxggepYmo0BuegIDppYS3b3cpdegRwkpyN3hw=="
     },
     "tmp": {
       "version": "0.0.33",
@@ -4894,13 +4881,12 @@
         "user-home": "^1.1.1"
       }
     },
-    "valida": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/valida/-/valida-2.4.0.tgz",
-      "integrity": "sha1-s+EOISv/tlNXHQ03UsfzcDBgqdE=",
+    "valida2": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/valida2/-/valida2-2.5.0.tgz",
+      "integrity": "sha512-KgJXi1e+TThYfrJV2HS8wXs+MEmsYuKnVZx/V0HW+lZv+keWLA+2OIzxmhNuashxLdJCGLXF0tDeNI8w2Sz7Gw==",
       "requires": {
         "async": "^0.9.0",
-        "is-float": "^1.0.0",
         "rsvp": "^3.0.14",
         "titlecase": "^1.1.2",
         "upper-case-first": "^1.1.2"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "sqlite3": "^4.0.6",
     "ssh2": "^0.5.0",
     "uuid": "^3.0.0",
-    "valida": "^2.0.0"
+    "valida2": "^2.5.0"
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",

--- a/src/validators/server.js
+++ b/src/validators/server.js
@@ -1,4 +1,4 @@
-import Valida from 'valida';
+import Valida from 'valida2';
 import { CLIENTS } from '../db';
 
 


### PR DESCRIPTION
valida appears to be unsupported (last commit was in 2017) and has a reported vulnerability on one of its dependencies (is-float). While the vulnerability is not actually an issue (as it's only if you use cli interface of is-float, which we do not), there's no point ignoring it. valida2 will also be worked upon to give typings and such in the future.

This, combined with #82, should resolve all outstanding vulnerabilities reported by `npm audit`.