### PR TITLE
use iv functions for cipher functions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,6 +24,7 @@
       }
     ],
 
-    "import/prefer-default-export": 0
+    "import/prefer-default-export": 0,
+    "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }]
   }
 }

--- a/spec/config.spec.js
+++ b/spec/config.spec.js
@@ -1,7 +1,10 @@
+import path from 'path';
 import { expect } from 'chai';
 import { config } from '../src';
 import { readJSONFile } from './../src/utils';
 import utilsStub from './utils-stub';
+import { decrypt } from '../src/crypto';
+
 
 const cryptoSecret = 'CHK`Ya91Hs{me!^8ndwPPaPPxwQ}`';
 
@@ -18,6 +21,30 @@ describe('config', () => {
 
       expect(findItem(fixtureBefore)).to.not.have.property('id');
       expect(findItem(fixtureAfter)).to.have.property('id');
+      const expected = await readJSONFile(path.join(__dirname, 'fixtures', '.sqlectron.prepared.json'), fixtureAfter);
+      expect(fixtureAfter.servers).to.be.same.length(expected.servers.length);
+      fixtureAfter.servers[0].id = expected.servers[0].id;
+      for (let i = 0; i < fixtureAfter.servers.length; i++) {
+        const expectedServer = expected.servers[i];
+        const actualServer = fixtureAfter.servers[i];
+        if (expectedServer.password) {
+          expect(decrypt(expected.servers[i].password, cryptoSecret)).to.equal(
+            decrypt(actualServer.password, cryptoSecret),
+          );
+          delete expectedServer.password;
+          delete actualServer.password;
+        }
+
+        if (expectedServer.ssh && expectedServer.ssh.password) {
+          expect(decrypt(expectedServer.ssh.password, cryptoSecret)).to.equal(
+            decrypt(actualServer.ssh.password, cryptoSecret),
+          );
+          delete expectedServer.ssh.password;
+          delete actualServer.ssh.password;
+        }
+
+        expect(expectedServer).to.eql(actualServer);
+      }
     });
   });
 

--- a/spec/fixtures/.sqlectron.prepared.json
+++ b/spec/fixtures/.sqlectron.prepared.json
@@ -6,8 +6,14 @@
       "host": "10.10.10.10",
       "port": 5432,
       "user": "user",
-      "password": "password",
-      "database": "company"
+      "password": {
+        "ivText": "VxYLslGSBsBBqjOyQ0X6ew==",
+        "encryptedText": "bdt6D8klaflnB84ZlmrQ/A=="
+      },
+      "database": "company",
+      "id": "778871c1-644b-47a3-be48-7ff03f757b15",
+      "ssl": false,
+      "encrypted": true
     },
     {
       "id": "c94cbafa-8977-4142-9f34-c84d382d8731",
@@ -16,8 +22,13 @@
       "host": "10.10.10.10",
       "port": 5432,
       "user": "user",
-      "password": "password",
-      "database": "company"
+      "password": {
+        "ivText": "1XdXvHDbfshaB0dtGuTrhw==",
+        "encryptedText": "2NdqJ3VhgkpQXu13r/NNLQ=="
+      },
+      "database": "company",
+      "ssl": false,
+      "encrypted": true
     },
     {
       "id": "ed2d52a7-d8ff-4fdd-897a-7033dee598f4",
@@ -27,7 +38,12 @@
       "port": 3306,
       "database": "authentication",
       "user": "root",
-      "password": "password"
+      "password": {
+        "ivText": "gWBYRDpY0nWka8lJj26jpA==",
+        "encryptedText": "oTf0hz8r8waJkff65m3fQg=="
+      },
+      "ssl": false,
+      "encrypted": true
     },
     {
       "encrypted": true,
@@ -41,7 +57,8 @@
       "password": {
         "ivText": "wGf6X9T+QSygOHqtgQPlcA==",
         "encryptedText": "0LySDs9WPAvwSS9Qv+W3/A=="
-      }
+      },
+      "ssl": false
     },
     {
       "encrypted": true,
@@ -52,7 +69,11 @@
       "port": 3306,
       "database": "authentication",
       "user": "root",
-      "password": "fa1d88ee82bd4439"
+      "password": {
+        "ivText": "pNr8A2hS+S71TVbOuRaOCw==",
+        "encryptedText": "9/GqyCfHUL5OVZknFbg15Q=="
+      },
+      "ssl": false
     },
     {
       "encrypted": true,
@@ -63,13 +84,20 @@
       "port": 3306,
       "database": "authentication",
       "user": "root",
-      "password": "fa1d88ee82bd4439",
+      "password": {
+        "ivText": "WOspPYHPinofkZ3++nd81g==",
+        "encryptedText": "/9fmafWdKTTzI0hvw1blIw=="
+      },
       "ssh": {
         "host": "10.10.10.10",
         "port": 22,
         "user": "core",
-        "password": "fa1d88ee82bd4439"
-      }
+        "password": {
+          "ivText": "otimYaEFXULqybphtFyi3g==",
+          "encryptedText": "8VokUHFkXOCUboz5pLa3Eg=="
+        }
+      },
+      "ssl": false
     },
     {
       "id": "f7baa5f0-42a2-4f51-b49d-26cf3bfe8221",
@@ -78,14 +106,19 @@
       "host": "localhost",
       "port": 5432,
       "user": "user",
-      "password": "password",
+      "password": {
+        "ivText": "jYYw+h5626N4yKn/Fs0Qaw==",
+        "encryptedText": "or5P+1SwaI5axBIC8BDuqg=="
+      },
       "database": "company",
       "ssh": {
         "host": "10.10.10.10",
         "port": 22,
         "privateKey": "~/.vagrant.d/insecure_private_key",
         "user": "core"
-      }
+      },
+      "ssl": false,
+      "encrypted": true
     },
     {
       "id": "40c1fc90-8bc2-4e77-a458-4140f4e9b40f",
@@ -94,14 +127,22 @@
       "host": "host.com",
       "port": 33,
       "user": "user",
-      "password": "passd",
+      "password": {
+        "ivText": "4K3ENy67yu6TVMwsJy/jSw==",
+        "encryptedText": "Qugn60QGk8OjgojXqUoOgA=="
+      },
       "database": "database",
       "ssh": {
         "host": "hostssh.com",
         "port": 22,
         "user": "usrssh",
-        "password": "pwdssh"
-      }
+        "password": {
+          "ivText": "9aqZuWGrbaXBodPQ3mhj9A==",
+          "encryptedText": "aUDcWrMWZIoxKZ0sj8xosA=="
+        }
+      },
+      "ssl": false,
+      "encrypted": true
     },
     {
       "id": "961dfdfe-2697-4d02-b8a2-ee2b33e4c2a1",
@@ -110,14 +151,22 @@
       "host": "hsot.com",
       "port": 3,
       "user": "user",
-      "password": "pass",
+      "password": {
+        "ivText": "3Oa5m80FQ4Jy+XJez+bVMA==",
+        "encryptedText": "i4v3ZdDfpKh5BnzRrZgfzQ=="
+      },
       "database": "databa",
       "ssh": {
         "host": "hostssh.com",
         "port": 33,
         "user": "user",
-        "password": "pass"
-      }
+        "password": {
+          "ivText": "R95eRnIjQGRjbwuutTG8PQ==",
+          "encryptedText": "sUECh1SMhgKArMR3BNmb1w=="
+        }
+      },
+      "ssl": false,
+      "encrypted": true
     },
     {
       "id": "df8b16d3-6ad4-4582-a5fd-58d18b5b50ae",
@@ -140,6 +189,7 @@
           "encryptedText": "Z9TrH05/Csxl9xA/FgIVXw=="
         }
       },
+      "ssl": false,
       "encrypted": true
     },
     {
@@ -149,8 +199,13 @@
       "host": "host.com",
       "port": 33,
       "user": "user",
-      "password": "paas",
-      "database": "databse"
+      "password": {
+        "ivText": "BAf8Q8Txw00Lw6ZY9fSuvw==",
+        "encryptedText": "E4HVp2mjNBj/TnCrZ5mOsQ=="
+      },
+      "database": "databse",
+      "ssl": false,
+      "encrypted": true
     },
     {
       "id": "0108f534-c5fa-441f-b4a6-68eed18d4389",
@@ -159,8 +214,13 @@
       "host": "hsot.com",
       "port": 33,
       "user": "user",
-      "password": "pass",
-      "database": "database"
+      "password": {
+        "ivText": "CUyDTgMShky4OtKkjNoMiw==",
+        "encryptedText": "2uITYtE4GNVELLxQJyw13Q=="
+      },
+      "database": "database",
+      "ssl": false,
+      "encrypted": true
     },
     {
       "id": "da0d6685-3c95-4c69-b9b8-4611da412064",
@@ -169,8 +229,13 @@
       "host": "hot.com",
       "port": 34,
       "user": "user",
-      "password": "pass",
-      "database": "data"
+      "password": {
+        "ivText": "JxNlxysUP7T1FLlzs87/IA==",
+        "encryptedText": "XpIDARGkJ5PPMUv0sIOE6Q=="
+      },
+      "database": "data",
+      "ssl": false,
+      "encrypted": true
     },
     {
       "id": "bcd9b635-f6c5-4c22-b04b-a17f3f80b7b5",
@@ -179,8 +244,13 @@
       "host": "host.com",
       "port": 33434,
       "user": "use",
-      "password": "pass",
-      "database": "database"
+      "password": {
+        "ivText": "wsejsrTGr2gnqhAr81coNQ==",
+        "encryptedText": "Be05WVbJUdZ1UWpSgCm5Ng=="
+      },
+      "database": "database",
+      "ssl": false,
+      "encrypted": true
     },
     {
       "id": "623b39d6-39cb-4c0a-bf69-7f00b94768a9",
@@ -189,8 +259,13 @@
       "host": "host",
       "port": 334,
       "user": "user",
-      "password": "pass",
-      "database": "data"
+      "password": {
+        "ivText": "09bSLl1ezCe9HUpBEhyEdQ==",
+        "encryptedText": "yrd60sTuawQvsrXcTwRskA=="
+      },
+      "database": "data",
+      "ssl": false,
+      "encrypted": true
     },
     {
       "id": "0c60edd4-9795-422e-9ba4-b70cd703ae08",
@@ -199,8 +274,13 @@
       "host": "hsot.com",
       "port": 3434,
       "user": "user",
-      "password": "padad",
-      "database": "data"
+      "password": {
+        "ivText": "460tqPlo3B/2mDd+U/tekQ==",
+        "encryptedText": "BTQvJcoLBqiHTESQFha31w=="
+      },
+      "database": "data",
+      "ssl": false,
+      "encrypted": true
     }
   ]
 }

--- a/src/config.js
+++ b/src/config.js
@@ -11,7 +11,7 @@ function sanitizeServer(server, cryptoSecret) {
   if (!srv.id) { srv.id = uuid.v4(); }
 
   // ensure has the new fileld SSL
-  if (typeof srv.ssl === 'undefined') { srv.ssl = false; }
+  srv.ssl = srv.ssl || false;
 
   // ensure all secret fields are encrypted
   if (typeof srv.encrypted === 'undefined') {
@@ -23,6 +23,19 @@ function sanitizeServer(server, cryptoSecret) {
 
     if (srv.ssh && srv.ssh.password) {
       srv.ssh.password = crypto.encrypt(srv.ssh.password, cryptoSecret);
+    }
+  } else if (srv.encrypted) {
+    if (srv.password && typeof srv.password === 'string') {
+      srv.password = crypto.encrypt(
+        crypto.unsafeDecrypt(srv.password, cryptoSecret),
+        cryptoSecret,
+      );
+    }
+    if (srv.ssh && srv.ssh.password && typeof srv.ssh.password === 'string') {
+      srv.ssh.password = crypto.encrypt(
+        crypto.unsafeDecrypt(srv.ssh.password, cryptoSecret),
+        cryptoSecret,
+      );
     }
   }
 

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -1,26 +1,62 @@
 // Reference: http://lollyrock.com/articles/nodejs-encryption
 import crypto from 'crypto';
 
-const algorithm = 'aes-256-ctr';
+const algorithm = 'aes-256-cbc';
 
-export function encrypt(text, secret) {
-  if (!secret) {
-    throw new Error('Missing crypto secret');
+export function encrypt(plainText, secret) {
+  if (!plainText) {
+    throw new Error('Missing plain text');
+  } else if (!secret) {
+    throw new Error('Missing encrypt secret');
   }
-
-  const cipher = crypto.createCipher(algorithm, secret);
-  let crypted = cipher.update(text, 'utf8', 'hex');
-  crypted += cipher.final('hex');
-  return crypted;
+  let key = Buffer.alloc(32);
+  key = Buffer.concat([Buffer.from(secret)], key.length);
+  const ivBytes = crypto.randomBytes(16);
+  const cipher = crypto.createCipheriv(algorithm, key, ivBytes);
+  return {
+    ivText: ivBytes.toString('base64'),
+    encryptedText: cipher.update(plainText, 'utf8', 'base64') + cipher.final('base64'),
+  };
 }
 
-export function decrypt(text, secret) {
+export function decrypt(encrypted, secret) {
+  if (!encrypted || !encrypted.ivText || !encrypted.encryptedText) {
+    throw new Error('Invalid encrypted valued');
+  } else if (!secret) {
+    throw new Error('Missing decrypt secret');
+  }
+
+  const iv = Buffer.from(encrypted.ivText, 'base64');
+  let key = Buffer.alloc(32);
+  key = Buffer.concat([Buffer.from(secret)], key.length);
+
+  if (iv.length !== 16) {
+    throw new Error('The encrypted value is not a valid format');
+  }
+
+  if (key.length !== 32) {
+    throw new Error('The secret is not valid format');
+  }
+
+  const decipher = crypto.createDecipheriv(algorithm, key, iv);
+  return decipher.update(encrypted.encryptedText, 'base64', 'utf8') + decipher.final('utf8');
+}
+
+/**
+ * Decrypts a value using the insecure createDecipher method.
+ *
+ * This method should not be used and only exists to give an upgrade path
+ * of existing sqlectron-core users to the much better iv functions above.
+ *
+ * @deprecated 8.1.0
+ * @param {string} text
+ * @param {string} secret
+ */
+export function unsafeDecrypt(text, secret) {
   if (!secret) {
     throw new Error('Missing crypto secret');
   }
 
-  const decipher = crypto.createDecipher(algorithm, secret);
-  let dec = decipher.update(text, 'hex', 'utf8');
-  dec += decipher.final('utf8');
-  return dec;
+  const decipher = crypto.createDecipher('aes-256-ctr', secret);
+  return decipher.update(text, 'hex', 'utf8') + decipher.final('utf8');
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -68,7 +68,7 @@ export function writeJSONFileSync(filename, data) {
 export function readFile(filename) {
   const filePath = resolveHomePathToAbsolute(filename);
   return new Promise((resolve, reject) => {
-    fs.readFile(path.resolve(filePath), (err, data) => {
+    fs.readFile(path.resolve(filePath), { encoding: 'utf-8' }, (err, data) => {
       if (err) return reject(err);
       resolve(data);
     });

--- a/src/validators/server.js
+++ b/src/validators/server.js
@@ -45,6 +45,34 @@ function boolValidator(ctx, options, value) {
   }
 }
 
+function passwordSanitizer(ctx, options, value) {
+  if (value === undefined || value === null) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    return Valida.sanitizers.trim(ctx, options, value);
+  }
+
+  return {
+    ivText: Valida.sanitizers.trim(ctx, options, value.ivText),
+    encryptedText: Valida.sanitizers.trim(ctx, options, value.encryptedText),
+  };
+}
+
+function passwordValidator(ctx, options, value) {
+  if (value === undefined || value === null) {
+    return;
+  }
+
+  if (typeof value === 'string') {
+    return Valida.validators.len(ctx, options, value);
+  }
+
+  return Valida.validators.len(ctx, options, value.ivText)
+    || Valida.validators.len(ctx, options, value.encryptedText);
+}
+
 
 const SSH_SCHEMA = {
   host: [
@@ -61,8 +89,8 @@ const SSH_SCHEMA = {
     { validator: Valida.Validator.len, min: 1 },
   ],
   password: [
-    { sanitizer: Valida.Sanitizer.trim },
-    { validator: Valida.Validator.len, min: 1 },
+    { sanitizer: passwordSanitizer },
+    { validator: passwordValidator, min: 1 },
   ],
   privateKey: [
     { sanitizer: Valida.Sanitizer.trim },
@@ -112,8 +140,8 @@ const SERVER_SCHEMA = {
     { validator: Valida.Validator.len, min: 1 },
   ],
   password: [
-    { sanitizer: Valida.Sanitizer.trim },
-    { validator: Valida.Validator.len, min: 1 },
+    { sanitizer: passwordSanitizer },
+    { validator: passwordValidator, min: 1 },
   ],
   ssh: [
     { validator: Valida.Validator.schema, schema: SSH_SCHEMA },


### PR DESCRIPTION
This moves sqlectron from using the deprecated and insecure createCipher and createDecipher methods to createCiperiv and createDicipheriv. However, sqlectron-core retains backwards compatibility in that it will still load old-style passwords and decode them, but will always use the new methods when encrypting the passwords. The library does not force a downstream consumer to necessarily upgrade to the newer crypto methods, but it is heavily encouraged.

Closes #51