### PR TITLE
fix wrong column order for createTableQuery for pg12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           - node-version: 10.x
             mysql-version: 5.7
             cassandra-version: 3.7
-            postgres-version: 9
+            postgres-version: 12
           - node-version: 12.x
             mysql-version: 5.7
             cassandra-version: 3.7

--- a/src/db/clients/postgresql.js
+++ b/src/db/clients/postgresql.js
@@ -356,6 +356,7 @@ export async function getTableCreateScript(conn, table, schema) {
       array_to_string(
         array_agg(
           '  ' || quote_ident(tabdef.column_name) || ' ' ||  tabdef.type || ' '|| tabdef.not_null
+          ORDER BY tabdef.column_order ASC
         )
         , E',\n'
       ) || E'\n);\n' ||
@@ -373,7 +374,8 @@ export async function getTableCreateScript(conn, table, schema) {
           WHEN a.attnotnull THEN 'NOT NULL'
         ELSE 'NULL'
         END AS not_null,
-        n.nspname as schema_name
+        n.nspname as schema_name,
+        a.attnum as column_order
       FROM pg_class c,
        pg_attribute a,
        pg_type t,


### PR DESCRIPTION
Moving from pg9 to pg12, the column order for the createTableQuery is now in the wrong order. This is probably due to the fact that array_agg does not actually guarantee an order unless you use an inner ORDER BY, where if you use an ORDER BY outside of it, the docs just say that it'll _probably_ work.

Fixes #79 