### PR TITLE
fix createTable test for mysql 8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
             cassandra-version: 3.7
             postgres-version: 9
           - node-version: 10.x
-            mysql-version: 5.7
+            mysql-version: 8
             cassandra-version: 3.7
             postgres-version: 9
           - node-version: 12.x

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -310,7 +310,19 @@ describe('db', () => {
           it('should return table create script', async () => {
             const [createScript] = await dbConn.getTableCreateScript('users');
 
-            if (dbClient === 'mysql') {
+            if (dbClient === 'mysql' && parseInt(dbConn.version()[0], 10) >= '8') {
+              expect(createScript).to.contain('CREATE TABLE `users` (\n' +
+              '  `id` int NOT NULL AUTO_INCREMENT,\n' +
+              '  `username` varchar(45) DEFAULT NULL,\n' +
+              '  `email` varchar(150) DEFAULT NULL,\n' +
+              '  `password` varchar(45) DEFAULT NULL,\n' +
+              '  `role_id` int DEFAULT NULL,\n' +
+              '  `createdat` datetime DEFAULT NULL,\n' +
+              '  PRIMARY KEY (`id`),\n' +
+              '  KEY `role_id` (`role_id`),\n' +
+              '  CONSTRAINT `users_ibfk_1` FOREIGN KEY (`role_id`) REFERENCES `roles` (`id`) ON DELETE CASCADE\n' +
+              ') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci');
+            } else if (dbClient === 'mysql') {
               expect(createScript).to.contain('CREATE TABLE `users` (\n' +
                 '  `id` int(11) NOT NULL AUTO_INCREMENT,\n' +
                 '  `username` varchar(45) DEFAULT NULL,\n' +


### PR DESCRIPTION
Fixes the createTable test under mysql8. The display width for integers (e.g. `int(11)`) was deprecated in MySQL 8 as it did not do what people thought it did (limit width of the column) and most software had it's own mechanisms for appropriately displaying the information which is what the display width was supposed to do.

Closes #78