### PR TITLE
replace prepublish with prepublishOnly in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "compile": "babel -d lib/ src/",
     "watch": "babel --watch -d lib/ src/",
-    "prepublish": "npm run compile",
+    "prepublishOnly": "npm run compile",
     "lint": "eslint src/ spec/",
     "test:mysql": "DB_CLIENTS=mysql npm run test",
     "test:sqlite": "DB_CLIENTS=sqlite npm run test",


### PR DESCRIPTION
prepublish was deprecated in npm@4 due to it being confusing to users as it would run both on publishing and installing a package. This task does not do anything necessary when running npm install for development, and is only really useful to ensure we have the latest compiled scripts in the lib/ directory before running npm publish, hence this is changed to prepublishOnly instead of prepare.