### PR TITLE
Add support for Cassandra 2.1 and fix tests for 3.10+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         include:
           - node-version: 6.x
             mysql-version: 5.7
-            cassandra-version: 3.0
+            cassandra-version: 2.1
             postgres-version: 9
           - node-version: 8.x
             mysql-version: 5.7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,11 +19,11 @@ jobs:
             postgres-version: 9
           - node-version: 8.x
             mysql-version: 5.7
-            cassandra-version: 3.0
+            cassandra-version: "3.0"
             postgres-version: 9
           - node-version: 10.x
             mysql-version: 5.7
-            cassandra-version: 3.0
+            cassandra-version: "3.0"
             postgres-version: 9
           - node-version: 10.x
             mysql-version: 5.7
@@ -31,7 +31,7 @@ jobs:
             postgres-version: 9
           - node-version: 12.x
             mysql-version: 5.7
-            cassandra-version: 3.0
+            cassandra-version: "3.0"
             postgres-version: 9
 
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,23 +15,23 @@ jobs:
         include:
           - node-version: 6.x
             mysql-version: 5.7
-            cassandra-version: 3.7
+            cassandra-version: 3.0
             postgres-version: 9
           - node-version: 8.x
             mysql-version: 5.7
-            cassandra-version: 3.7
+            cassandra-version: 3.0
             postgres-version: 9
           - node-version: 10.x
             mysql-version: 5.7
-            cassandra-version: 3.7
+            cassandra-version: 3.0
             postgres-version: 9
           - node-version: 10.x
             mysql-version: 5.7
-            cassandra-version: 3.7
+            cassandra-version: 3.11
             postgres-version: 9
           - node-version: 12.x
             mysql-version: 5.7
-            cassandra-version: 3.7
+            cassandra-version: 3.0
             postgres-version: 9
 
     env:

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -782,7 +782,11 @@ describe('db', () => {
                 expect(secondResult).to.have.deep.property('rowCount').to.eql(1);
               } catch (err) {
                 if (dbClient === 'cassandra') {
-                  expect(err.message).to.match(/missing EOF at 'select'/);
+                  if (parseFloat(dbConn.version()) >= 3.10) {
+                    expect(err.message).to.match(/mismatched input 'select' expecting EOF/);
+                  } else {
+                    expect(err.message).to.match(/missing EOF at 'select'/);
+                  }
                 } else {
                   throw err;
                 }
@@ -858,7 +862,11 @@ describe('db', () => {
                 }
               } catch (err) {
                 if (dbClient === 'cassandra') {
-                  expect(err.message).to.match(/missing EOF at 'insert'/);
+                  if (parseFloat(dbConn.version()) >= 3.10) {
+                    expect(err.message).to.match(/mismatched input 'insert' expecting EOF/);
+                  } else {
+                    expect(err.message).to.match(/missing EOF at 'insert'/);
+                  }
                 } else {
                   throw err;
                 }
@@ -930,7 +938,11 @@ describe('db', () => {
                 }
               } catch (err) {
                 if (dbClient === 'cassandra') {
-                  expect(err.message).to.match(/missing EOF at 'delete'/);
+                  if (parseFloat(dbConn.version()) >= 3.10) {
+                    expect(err.message).to.match(/mismatched input 'delete' expecting EOF/);
+                  } else {
+                    expect(err.message).to.match(/missing EOF at 'delete'/);
+                  }
                 } else {
                   throw err;
                 }
@@ -1002,7 +1014,11 @@ describe('db', () => {
                 }
               } catch (err) {
                 if (dbClient === 'cassandra') {
-                  expect(err.message).to.match(/missing EOF at 'update'/);
+                  if (parseFloat(dbConn.version()) >= 3.10) {
+                    expect(err.message).to.match(/mismatched input 'update' expecting EOF/);
+                  } else {
+                    expect(err.message).to.match(/missing EOF at 'update'/);
+                  }
                 } else {
                   throw err;
                 }

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -681,7 +681,11 @@ describe('db', () => {
                 }
               } catch (err) {
                 if (dbClient === 'cassandra') {
-                  expect(err.message).to.eql('line 1:13 mismatched character \'<EOF>\' expecting set null');
+                  if (dbConn.version().split('.')[0] === '2') {
+                    expect(err.message).to.eql('line 0:-1 no viable alternative at input \'<EOF>\'');
+                  } else {
+                    expect(err.message).to.eql('line 1:13 mismatched character \'<EOF>\' expecting set null');
+                  }
                 } else {
                   throw err;
                 }
@@ -782,7 +786,7 @@ describe('db', () => {
                 expect(secondResult).to.have.deep.property('rowCount').to.eql(1);
               } catch (err) {
                 if (dbClient === 'cassandra') {
-                  if (parseFloat(dbConn.version()) >= 3.10) {
+                  if (parseFloat(dbConn.version().split('.').slice(0, 2)) >= 3.10) {
                     expect(err.message).to.match(/mismatched input 'select' expecting EOF/);
                   } else {
                     expect(err.message).to.match(/missing EOF at 'select'/);
@@ -862,7 +866,7 @@ describe('db', () => {
                 }
               } catch (err) {
                 if (dbClient === 'cassandra') {
-                  if (parseFloat(dbConn.version()) >= 3.10) {
+                  if (parseFloat(dbConn.version().split('.').slice(0, 2)) >= 3.10) {
                     expect(err.message).to.match(/mismatched input 'insert' expecting EOF/);
                   } else {
                     expect(err.message).to.match(/missing EOF at 'insert'/);
@@ -938,7 +942,7 @@ describe('db', () => {
                 }
               } catch (err) {
                 if (dbClient === 'cassandra') {
-                  if (parseFloat(dbConn.version()) >= 3.10) {
+                  if (parseFloat(dbConn.version().split('.').slice(0, 2)) >= 3.10) {
                     expect(err.message).to.match(/mismatched input 'delete' expecting EOF/);
                   } else {
                     expect(err.message).to.match(/missing EOF at 'delete'/);
@@ -1014,7 +1018,7 @@ describe('db', () => {
                 }
               } catch (err) {
                 if (dbClient === 'cassandra') {
-                  if (parseFloat(dbConn.version()) >= 3.10) {
+                  if (parseFloat(dbConn.version().split('.').slice(0, 2)) >= 3.10) {
                     expect(err.message).to.match(/mismatched input 'update' expecting EOF/);
                   } else {
                     expect(err.message).to.match(/missing EOF at 'update'/);

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -786,7 +786,7 @@ describe('db', () => {
                 expect(secondResult).to.have.deep.property('rowCount').to.eql(1);
               } catch (err) {
                 if (dbClient === 'cassandra') {
-                  if (parseFloat(dbConn.version().split('.').slice(0, 2)) >= 3.10) {
+                  if (parseFloat(dbConn.version().split('.').slice(0, 2).join('.')) >= 3.10) {
                     expect(err.message).to.match(/mismatched input 'select' expecting EOF/);
                   } else {
                     expect(err.message).to.match(/missing EOF at 'select'/);
@@ -866,7 +866,7 @@ describe('db', () => {
                 }
               } catch (err) {
                 if (dbClient === 'cassandra') {
-                  if (parseFloat(dbConn.version().split('.').slice(0, 2)) >= 3.10) {
+                  if (parseFloat(dbConn.version().split('.').slice(0, 2).join('.')) >= 3.10) {
                     expect(err.message).to.match(/mismatched input 'insert' expecting EOF/);
                   } else {
                     expect(err.message).to.match(/missing EOF at 'insert'/);
@@ -942,7 +942,7 @@ describe('db', () => {
                 }
               } catch (err) {
                 if (dbClient === 'cassandra') {
-                  if (parseFloat(dbConn.version().split('.').slice(0, 2)) >= 3.10) {
+                  if (parseFloat(dbConn.version().split('.').slice(0, 2).join('.')) >= 3.10) {
                     expect(err.message).to.match(/mismatched input 'delete' expecting EOF/);
                   } else {
                     expect(err.message).to.match(/missing EOF at 'delete'/);
@@ -1018,7 +1018,7 @@ describe('db', () => {
                 }
               } catch (err) {
                 if (dbClient === 'cassandra') {
-                  if (parseFloat(dbConn.version().split('.').slice(0, 2)) >= 3.10) {
+                  if (parseFloat(dbConn.version().split('.').slice(0, 2).join('.')) >= 3.10) {
                     expect(err.message).to.match(/mismatched input 'update' expecting EOF/);
                   } else {
                     expect(err.message).to.match(/missing EOF at 'update'/);

--- a/src/db/clients/cassandra.js
+++ b/src/db/clients/cassandra.js
@@ -23,36 +23,30 @@ export default function (server, database) {
         return reject(err);
       }
 
-      client.execute('SELECT cql_version FROM system.local;', (error, data) => {
-        if (error) {
-          client.shutdown();
-          return reject(error);
-        }
-        const version = data.rows[0].cql_version;
+      client.version = client.getState().getConnectedHosts()[0].cassandraVersion;
 
-        logger().debug('connected');
-        resolve({
-          wrapIdentifier,
-          version,
-          disconnect: () => disconnect(client),
-          listTables: (db) => listTables(client, db),
-          listViews: () => listViews(client),
-          listRoutines: () => listRoutines(client),
-          listTableColumns: (db, table) => listTableColumns(client, db, table),
-          listTableTriggers: (table) => listTableTriggers(client, table),
-          listTableIndexes: (db, table) => listTableIndexes(client, table),
-          listSchemas: () => listSchemas(client),
-          getTableReferences: (table) => getTableReferences(client, table),
-          getTableKeys: (db, table) => getTableKeys(client, db, table),
-          query: (queryText) => executeQuery(client, queryText),
-          executeQuery: (queryText) => executeQuery(client, queryText),
-          listDatabases: () => listDatabases(client),
-          getQuerySelectTop: (table, limit) => getQuerySelectTop(client, table, limit),
-          getTableCreateScript: (table) => getTableCreateScript(client, table),
-          getViewCreateScript: (view) => getViewCreateScript(client, view),
-          getRoutineCreateScript: (routine) => getRoutineCreateScript(client, routine),
-          truncateAllTables: (db) => truncateAllTables(client, db),
-        });
+      logger().debug('connected');
+      resolve({
+        wrapIdentifier,
+        version: client.version,
+        disconnect: () => disconnect(client),
+        listTables: (db) => listTables(client, db),
+        listViews: () => listViews(client),
+        listRoutines: () => listRoutines(client),
+        listTableColumns: (db, table) => listTableColumns(client, db, table),
+        listTableTriggers: (table) => listTableTriggers(client, table),
+        listTableIndexes: (db, table) => listTableIndexes(client, table),
+        listSchemas: () => listSchemas(client),
+        getTableReferences: (table) => getTableReferences(client, table),
+        getTableKeys: (db, table) => getTableKeys(client, db, table),
+        query: (queryText) => executeQuery(client, queryText),
+        executeQuery: (queryText) => executeQuery(client, queryText),
+        listDatabases: () => listDatabases(client),
+        getQuerySelectTop: (table, limit) => getQuerySelectTop(client, table, limit),
+        getTableCreateScript: (table) => getTableCreateScript(client, table),
+        getViewCreateScript: (view) => getViewCreateScript(client, view),
+        getRoutineCreateScript: (routine) => getRoutineCreateScript(client, routine),
+        truncateAllTables: (db) => truncateAllTables(client, db),
       });
     });
   });


### PR DESCRIPTION
Supersedes work from #53 to also get this tested on cassandra 3.10+, while fixing the merge conflicts, and simplifying the version select.

The Cassandra driver we use works with both Cassandra 2.x and 3.x, however, the system schemas are different. To make Sqlectron work with Cassandra 2.x, we need to send different metadata queries to older servers.

The approach in this PR is to use the metadata provided by the driver whenever possible (already implemented in the schema parser from of the driver). Otherwise, we define two variants of the schema queries and send one corresponding to the server version.

