### PR TITLE
fix running truncateAllTables for sqlsrv with fk constraints

### DIFF
--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -659,11 +659,6 @@ describe('db', () => {
           });
 
           afterEach(async () => {
-            // TODO: Fix truncateAllTables for SQLServer 2017
-            if (dbClient === 'sqlserver') {
-              await dbConn.executeQuery('DELETE FROM users');
-            }
-
             await dbConn.truncateAllTables();
           });
 

--- a/src/db/clients/sqlserver.js
+++ b/src/db/clients/sqlserver.js
@@ -397,15 +397,15 @@ export async function truncateAllTables(conn) {
     const { data } = await driverExecuteQuery(connClient, { query: sql });
 
     const disableForeignKeys = data.map((row) => `
-      ALTER TABLE ${wrapIdentifier(schema)}.${wrapIdentifier(row.table_name)} NOCHECK CONSTRAINT all
-    `).join(';');
+      ALTER TABLE ${wrapIdentifier(schema)}.${wrapIdentifier(row.table_name)} NOCHECK CONSTRAINT all;
+    `).join('');
     const truncateAll = data.map((row) => `
       DELETE FROM ${wrapIdentifier(schema)}.${wrapIdentifier(row.table_name)};
       DBCC CHECKIDENT ('${schema}.${row.table_name}', RESEED, 0);
     `).join('');
     const enableForeignKeys = data.map((row) => `
-      ALTER TABLE ${wrapIdentifier(schema)}.${wrapIdentifier(row.table_name)} WITH CHECK CHECK CONSTRAINT all
-    `).join(';');
+      ALTER TABLE ${wrapIdentifier(schema)}.${wrapIdentifier(row.table_name)} WITH CHECK CHECK CONSTRAINT all;
+    `).join('');
 
     await driverExecuteQuery(connClient, {
       query: disableForeignKeys + truncateAll + enableForeignKeys,

--- a/src/db/clients/sqlserver.js
+++ b/src/db/clients/sqlserver.js
@@ -396,10 +396,16 @@ export async function truncateAllTables(conn) {
 
     const { data } = await driverExecuteQuery(connClient, { query: sql });
 
+    const disableForeignKeys = data.map((row) => `
+      ALTER TABLE ${wrapIdentifier(schema)}.${wrapIdentifier(row.table_name)} NOCHECK CONSTRAINT all
+    `).join(';');
     const truncateAll = data.map((row) => `
-      DELETE FROM ${wrapIdentifier(schema)}.${wrapIdentifier(row.table_name)}
+      DELETE FROM ${wrapIdentifier(schema)}.${wrapIdentifier(row.table_name)};
       DBCC CHECKIDENT ('${schema}.${row.table_name}', RESEED, 0);
     `).join('');
+    const disableForeignKeys = data.map((row) => `
+      ALTER TABLE ${wrapIdentifier(schema)}.${wrapIdentifier(row.table_name)} WITH CHECK CHECK CONSTRAINT all
+    `).join(';');
 
     await driverExecuteQuery(connClient, { query: truncateAll, multiple: true });
   });

--- a/src/db/clients/sqlserver.js
+++ b/src/db/clients/sqlserver.js
@@ -403,11 +403,14 @@ export async function truncateAllTables(conn) {
       DELETE FROM ${wrapIdentifier(schema)}.${wrapIdentifier(row.table_name)};
       DBCC CHECKIDENT ('${schema}.${row.table_name}', RESEED, 0);
     `).join('');
-    const disableForeignKeys = data.map((row) => `
+    const enableForeignKeys = data.map((row) => `
       ALTER TABLE ${wrapIdentifier(schema)}.${wrapIdentifier(row.table_name)} WITH CHECK CHECK CONSTRAINT all
     `).join(';');
 
-    await driverExecuteQuery(connClient, { query: truncateAll, multiple: true });
+    await driverExecuteQuery(connClient, {
+      query: disableForeignKeys + truncateAll + enableForeignKeys,
+      multiple: true,
+    });
   });
 }
 


### PR DESCRIPTION
Closes #70 

When going to truncate the tables under sqlserver, this makes it so that we first disable all constraints on all tables, truncate them all, and then re-enable the constraints.