### PR TITLE
rework validateUniqueId to not always pass

### DIFF
--- a/src/servers.js
+++ b/src/servers.js
@@ -15,8 +15,10 @@ export async function add(server, cryptoSecret) {
   await validate(srv);
 
   const data = await config.get();
-  const newId = uuid.v4();
-  validateUniqueId(data.servers, newId);
+  let newId;
+  do {
+    newId = uuid.v4();
+  } while (!validateUniqueId(data.servers, newId));
 
   srv = encryptSecrects(srv, cryptoSecret);
 
@@ -33,7 +35,6 @@ export async function update(server, cryptoSecret) {
   await validate(srv);
 
   const data = await config.get();
-  validateUniqueId(data.servers, srv.id);
 
   const index = data.servers.findIndex((item) => item.id === srv.id);
   srv = encryptSecrects(srv, cryptoSecret, data.servers[index]);

--- a/src/validators/server.js
+++ b/src/validators/server.js
@@ -171,11 +171,9 @@ export async function validate(server) {
 
 
 export function validateUniqueId(servers, serverId) {
-  if (!serverId) { return; }
+  if (!serverId) {
+    throw new Error('serverId should be set');
+  }
 
-  const server = servers.find((srv) => srv.id === serverId);
-  if (!server) { return; }
-  if (serverId && server.id === serverId) { return; }
-
-  throw new Error('Already exist another server with same id');
+  return !servers.find((srv) => srv.id === serverId);
 }


### PR DESCRIPTION
In 93889f922efdc6050f873f636c37ff4cd925acf1, it was set-up that each entry in the server list must have a unique name to be used. This function was used to ensure that the new name for a server did not collide with the names of any other server. When 240e5f334fea120f90a65b38da90c9f6b60cc9d4 reworked it so that each server entry used a uuidv4 id instead, it made the the `validateUniqueId` function always returns and would never throw an exception. 

This patch reworks it so that this function is only used when adding a server, and to make it return true/false until a unique id is generated that has not been used before. It's probable this function will never run more than once, but better be safe than sorry.

The check is removed from updating a server as the server id must exist and must be in the servers list, or else the very next line would not work.