### PR TITLE
Fix clientValidator not properly ensuring valid client

### DIFF
--- a/src/validators/server.js
+++ b/src/validators/server.js
@@ -26,7 +26,7 @@ function serverAddressValidator(ctx) {
 
 function clientValidator(ctx, options, value) {
   if (typeof value === 'undefined' || value === null) { return undefined; }
-  if (!~CLIENTS.some((dbClient) => dbClient.key === ctx.obj.client)) {
+  if (!CLIENTS.some((dbClient) => dbClient.key === value)) {
     return {
       validator: 'clientValidator',
       msg: 'Invalid client type',


### PR DESCRIPTION
The bitwise operator here messes up the boolean return of `.some` and causes this check to then always trivially pass.

example:
```javascript
> !~[1,2].some(v => v === 1);
false
> !~[1,2].some(v => v === 3);
false
```

Given that `.some` returns a boolean, we can safely remove the bitwise operator, and get things working as we would expect.