### PR TITLE
fix sqlserver client breaking if using CS collation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,22 +17,27 @@ jobs:
             mysql-version: 5.7
             cassandra-version: 2.1
             postgres-version: 9
+            sqlserver-collation: Latin1_General_CI_AS
           - node-version: 8.x
             mysql-version: 5.7
             cassandra-version: "3.0"
             postgres-version: 9
+            sqlserver-collation: Latin1_General_CI_AS
           - node-version: 10.x
             mysql-version: 5.7
             cassandra-version: "3.0"
             postgres-version: 9
+            sqlserver-collation: Latin1_General_CI_AS
           - node-version: 10.x
             mysql-version: 8
             cassandra-version: 3.11
             postgres-version: 12
+            sqlserver-collation: Latin1_General_CS_AS
           - node-version: 12.x
             mysql-version: 5.7
             cassandra-version: "3.0"
             postgres-version: 9
+            sqlserver-collation: Latin1_General_CS_AS
 
     env:
       CASSANDRA_PORT: tcp://localhost:9042
@@ -63,7 +68,7 @@ jobs:
     - name: Create Cassandra Container
       run: docker run --rm -d --name cassandra -p 9042:9042 -v ${GITHUB_WORKSPACE}/spec/databases/cassandra/schema:/docker-entrypoint-initdb.d  cassandra:${{ matrix.cassandra-version }}
     - name: Create SQLServer Container
-      run: docker run --rm -d --name sqlserver -p 1433:1433 -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Password12!" -v ${GITHUB_WORKSPACE}/spec/databases/sqlserver/schema:/docker-entrypoint-initdb.d mcr.microsoft.com/mssql/server:2017-latest
+      run: docker run --rm -d --name sqlserver -p 1433:1433 -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Password12!" -e "MSSQL_COLLATION=${{ sqlserver-collation }}" -v ${GITHUB_WORKSPACE}/spec/databases/sqlserver/schema:/docker-entrypoint-initdb.d mcr.microsoft.com/mssql/server:2017-latest
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
     - name: Create Cassandra Container
       run: docker run --rm -d --name cassandra -p 9042:9042 -v ${GITHUB_WORKSPACE}/spec/databases/cassandra/schema:/docker-entrypoint-initdb.d  cassandra:${{ matrix.cassandra-version }}
     - name: Create SQLServer Container
-      run: docker run --rm -d --name sqlserver -p 1433:1433 -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Password12!" -e "MSSQL_COLLATION=${{ sqlserver-collation }}" -v ${GITHUB_WORKSPACE}/spec/databases/sqlserver/schema:/docker-entrypoint-initdb.d mcr.microsoft.com/mssql/server:2017-latest
+      run: docker run --rm -d --name sqlserver -p 1433:1433 -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Password12!" -e "MSSQL_COLLATION=${{ matrix.sqlserver-collation }}" -v ${GITHUB_WORKSPACE}/spec/databases/sqlserver/schema:/docker-entrypoint-initdb.d mcr.microsoft.com/mssql/server:2017-latest
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:

--- a/spec/databases/sqlserver/schema/schema.sql
+++ b/spec/databases/sqlserver/schema/schema.sql
@@ -17,7 +17,7 @@ CREATE TABLE dbo.users
     CONSTRAINT fk_user_role FOREIGN KEY (role_id) REFERENCES roles (id))
 END;
 
-IF EXISTS (SELECT table_name FROM information_schema.views WHERE table_name = 'email_view')
+IF EXISTS (SELECT table_name FROM INFORMATION_SCHEMA.VIEWS WHERE table_name = 'email_view')
    DROP VIEW dbo.email_view
 GO
 

--- a/src/db/clients/sqlserver.js
+++ b/src/db/clients/sqlserver.js
@@ -132,7 +132,7 @@ export async function listTables(conn, filter) {
     SELECT
       table_schema,
       table_name
-    FROM information_schema.tables
+    FROM INFORMATION_SCHEMA.TABLES
     WHERE table_type NOT LIKE '%VIEW%'
     ${schemaFilter ? `AND ${schemaFilter}` : ''}
     ORDER BY table_schema, table_name
@@ -152,7 +152,7 @@ export async function listViews(conn, filter) {
     SELECT
       table_schema,
       table_name
-    FROM information_schema.views
+    FROM INFORMATION_SCHEMA.VIEWS
     ${schemaFilter ? `WHERE ${schemaFilter}` : ''}
     ORDER BY table_schema, table_name
   `;
@@ -172,7 +172,7 @@ export async function listRoutines(conn, filter) {
       routine_schema,
       routine_name,
       routine_type
-    FROM information_schema.routines
+    FROM INFORMATION_SCHEMA.ROUTINES
     ${schemaFilter ? `WHERE ${schemaFilter}` : ''}
     GROUP BY routine_schema, routine_name, routine_type
     ORDER BY routine_schema, routine_name
@@ -190,7 +190,7 @@ export async function listRoutines(conn, filter) {
 export async function listTableColumns(conn, database, table) {
   const sql = `
     SELECT column_name, data_type
-    FROM information_schema.columns
+    FROM INFORMATION_SCHEMA.COLUMNS
     WHERE table_name = '${table}'
     ORDER BY ordinal_position
   `;
@@ -227,7 +227,7 @@ export async function listSchemas(conn, filter) {
   const schemaFilter = buildSchemaFilter(filter);
   const sql = `
     SELECT schema_name
-    FROM information_schema.schemata
+    FROM INFORMATION_SCHEMA.SCHEMATA
     ${schemaFilter ? `WHERE ${schemaFilter}` : ''}
     ORDER BY schema_name
   `;
@@ -272,8 +272,8 @@ export async function getTableKeys(conn, database, table) {
       ELSE NULL
       END AS referenced_table_name,
       tc.constraint_type
-    FROM information_schema.table_constraints AS tc
-    JOIN information_schema.key_column_usage AS kcu
+    FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc
+    JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu
       ON tc.constraint_name = kcu.constraint_name
     JOIN sys.foreign_keys as sfk
       ON sfk.parent_object_id = OBJECT_ID(tc.table_name)
@@ -297,10 +297,10 @@ export async function getTableCreateScript(conn, table) {
     SELECT  ('CREATE TABLE ' + so.name + ' (' +
       CHAR(13)+CHAR(10) + REPLACE(o.list, '&#x0D;', CHAR(13)) +
       ')' + CHAR(13)+CHAR(10) +
-      CASE WHEN tc.Constraint_Name IS NULL THEN ''
+      CASE WHEN tc.constraint_name IS NULL THEN ''
            ELSE + CHAR(13)+CHAR(10) + 'ALTER TABLE ' + so.Name +
-           ' ADD CONSTRAINT ' + tc.Constraint_Name  +
-           ' PRIMARY KEY ' + '(' + LEFT(j.List, Len(j.List)-1) + ')'
+           ' ADD CONSTRAINT ' + tc.constraint_name  +
+           ' PRIMARY KEY ' + '(' + LEFT(j.list, Len(j.list)-1) + ')'
       END) AS createtable
     FROM sysobjects so
     CROSS APPLY
@@ -330,26 +330,26 @@ export async function getTableCreateScript(conn, table) {
             cast(ident_incr(so.name) AS varchar) + ')'
           ELSE ''
           END + ' ' +
-           (CASE WHEN IS_NULLABLE = 'No'
+           (CASE WHEN UPPER(IS_NULLABLE) = 'NO'
                  THEN 'NOT '
                  ELSE ''
           END ) + 'NULL' +
-          CASE WHEN information_schema.columns.COLUMN_DEFAULT IS NOT NULL
-               THEN 'DEFAULT '+ information_schema.columns.COLUMN_DEFAULT
+          CASE WHEN INFORMATION_SCHEMA.COLUMNS.column_default IS NOT NULL
+               THEN 'DEFAULT '+ INFORMATION_SCHEMA.COLUMNS.column_default
                ELSE ''
           END + ',' + CHAR(13)+CHAR(10)
-       FROM information_schema.columns WHERE table_name = so.name
+       FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name = so.name
        ORDER BY ordinal_position
        FOR XML PATH('')
     ) o (list)
-    LEFT JOIN information_schema.table_constraints tc
-    ON  tc.Table_name       = so.Name
-    AND tc.Constraint_Type  = 'PRIMARY KEY'
+    LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc
+    ON  tc.table_name       = so.name
+    AND tc.constraint_type  = 'PRIMARY KEY'
     CROSS APPLY
-        (SELECT Column_Name + ', '
-         FROM   information_schema.key_column_usage kcu
-         WHERE  kcu.Constraint_Name = tc.Constraint_Name
-         ORDER BY ORDINAL_POSITION
+        (SELECT column_name + ', '
+         FROM   INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
+         WHERE  kcu.constraint_name = tc.constraint_name
+         ORDER BY ordinal_position
          FOR XML PATH('')
         ) j (list)
     WHERE   xtype = 'U'
@@ -373,7 +373,7 @@ export async function getViewCreateScript(conn, view) {
 export async function getRoutineCreateScript(conn, routine) {
   const sql = `
     SELECT routine_definition
-    FROM information_schema.routines
+    FROM INFORMATION_SCHEMA.ROUTINES
     WHERE routine_name = '${routine}'
   `;
 
@@ -389,7 +389,7 @@ export async function truncateAllTables(conn) {
 
     const sql = `
       SELECT table_name
-      FROM information_schema.tables
+      FROM INFORMATION_SCHEMA.TABLES
       WHERE table_schema = '${schema}'
       AND table_type NOT LIKE '%VIEW%'
     `;


### PR DESCRIPTION
When using a CS collation (such as `Latin1_General_CS_AS`), the sqlserver client would break due to mainly that all information_schema tables are capitalized (e.g. `INFORMATION_SCHEMA.VIEWS`) and that certain things (like `IS_NULLABLE`) now return a fully capitalized result. The former we can just always use the upper case table names and it'll work on both CS and CI collations. For the latter, we just need to make sure to `UPPER` the columns in question before checking against their result.