### PR TITLE
Add support for mariadb client

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
       MYSQL_ENV_MYSQL_DATABASE: sqlectron
       MYSQL_PWD: Password12!
       MARIADB_PORT: tcp://localhost:3307
-      MARIADB_ENV_MARIADBL_USER: root
+      MARIADB_ENV_MARIADB_USER: root
       MARIADB_ENV_MARIADB_PASSWORD: Password12!
       MARIADB_ENV_MARIADB_DATABASE: sqlectron
       MARIADB_PWD: Password12!
@@ -81,6 +81,7 @@ jobs:
       run: docker run --rm -d --name cassandra -p 9042:9042 -v ${GITHUB_WORKSPACE}/spec/databases/cassandra/schema:/docker-entrypoint-initdb.d  cassandra:${{ matrix.cassandra-version }}
     - name: Create SQLServer Container
       run: docker run --rm -d --name sqlserver -p 1433:1433 -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Password12!" -e "MSSQL_COLLATION=${{ matrix.sqlserver-collation }}" -v ${GITHUB_WORKSPACE}/spec/databases/sqlserver/schema:/docker-entrypoint-initdb.d mcr.microsoft.com/mssql/server:2017-latest
+
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,11 @@ jobs:
       MYSQL_ENV_MYSQL_PASSWORD: Password12!
       MYSQL_ENV_MYSQL_DATABASE: sqlectron
       MYSQL_PWD: Password12!
+      MARIADB_PORT: tcp://localhost:3307
+      MARIADB_ENV_MARIADBL_USER: root
+      MARIADB_ENV_MARIADB_PASSWORD: Password12!
+      MARIADB_ENV_MARIADB_DATABASE: sqlectron
+      MARIADB_PWD: Password12!
       SQLSERVER_ENV_SQLSERVER_HOST: localhost
       SQLSERVER_ENV_SQLSERVER_PORT: 1433
       SQLSERVER_ENV_SQLSERVER_USER: sa
@@ -69,7 +74,7 @@ jobs:
     - name: Create MySQL Container
       run: docker run --rm -d --name mysql -e "MYSQL_ROOT_PASSWORD=Password12!" -e "MYSQL_DATABASE=sqlectron" -p 3306:3306 -v ${GITHUB_WORKSPACE}/spec/databases/mysql/schema:/docker-entrypoint-initdb.d mysql:${{ matrix.mysql-version }}
     - name: Create MariaDB Container
-      run: docker run --rm -d --name mariadb -e "MYSQL_ROOT_PASSWORD=Password12!" -e "MYSQL_DATABASE=sqlectron" -p 3306:3306 -v ${GITHUB_WORKSPACE}/spec/databases/mysql/schema:/docker-entrypoint-initdb.d mariadb:${{ matrix.maraidb-version }}
+      run: docker run --rm -d --name mariadb -e "MYSQL_ROOT_PASSWORD=Password12!" -e "MYSQL_DATABASE=sqlectron" -p 3307:3306 -v ${GITHUB_WORKSPACE}/spec/databases/mysql/schema:/docker-entrypoint-initdb.d mariadb:${{ matrix.maraidb-version }}
     - name: Create Postgres Container
       run: docker run --rm -d --name postgres -e "POSTGRES_PASSWORD=Password12!" -e "POSTGRES_DB=sqlectron" -p 5432:5432 -v ${GITHUB_WORKSPACE}/spec/databases/postgresql/schema:/docker-entrypoint-initdb.d postgres:${{ matrix.postgres-version }}
     - name: Create Cassandra Container

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Create MySQL Container
       run: docker run --rm -d --name mysql -e "MYSQL_ROOT_PASSWORD=Password12!" -e "MYSQL_DATABASE=sqlectron" -p 3306:3306 -v ${GITHUB_WORKSPACE}/spec/databases/mysql/schema:/docker-entrypoint-initdb.d mysql:${{ matrix.mysql-version }}
     - name: Create MariaDB Container
-      run: docker run --rm -d --name mariadb -e "MYSQL_ROOT_PASSWORD=Password12!" -e "MYSQL_DATABASE=sqlectron" -p 3306:3306 -v ${GITHUB_WORKSPACE}/spec/databases/mysql/schema:/docker-entrypoint-initdb.d mariadb:${{ matrix.mysql-version }}
+      run: docker run --rm -d --name mariadb -e "MYSQL_ROOT_PASSWORD=Password12!" -e "MYSQL_DATABASE=sqlectron" -p 3306:3306 -v ${GITHUB_WORKSPACE}/spec/databases/mysql/schema:/docker-entrypoint-initdb.d mariadb:${{ matrix.maraidb-version }}
     - name: Create Postgres Container
       run: docker run --rm -d --name postgres -e "POSTGRES_PASSWORD=Password12!" -e "POSTGRES_DB=sqlectron" -p 5432:5432 -v ${GITHUB_WORKSPACE}/spec/databases/postgresql/schema:/docker-entrypoint-initdb.d postgres:${{ matrix.postgres-version }}
     - name: Create Cassandra Container

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,26 +15,31 @@ jobs:
         include:
           - node-version: 6.x
             mysql-version: 5.7
+            maraidb-version: 10.1
             cassandra-version: 2.1
             postgres-version: 9
             sqlserver-collation: Latin1_General_CI_AS
           - node-version: 8.x
             mysql-version: 5.7
+            maraidb-version: 10.1
             cassandra-version: "3.0"
             postgres-version: 9
             sqlserver-collation: Latin1_General_CI_AS
           - node-version: 10.x
             mysql-version: 5.7
+            maraidb-version: 10.1
             cassandra-version: "3.0"
             postgres-version: 9
             sqlserver-collation: Latin1_General_CI_AS
           - node-version: 10.x
             mysql-version: 8
+            maraidb-version: 10.5
             cassandra-version: 3.11
             postgres-version: 12
             sqlserver-collation: Latin1_General_CS_AS
           - node-version: 12.x
             mysql-version: 5.7
+            maraidb-version: 10.1
             cassandra-version: "3.0"
             postgres-version: 9
             sqlserver-collation: Latin1_General_CS_AS
@@ -63,6 +68,8 @@ jobs:
 
     - name: Create MySQL Container
       run: docker run --rm -d --name mysql -e "MYSQL_ROOT_PASSWORD=Password12!" -e "MYSQL_DATABASE=sqlectron" -p 3306:3306 -v ${GITHUB_WORKSPACE}/spec/databases/mysql/schema:/docker-entrypoint-initdb.d mysql:${{ matrix.mysql-version }}
+    - name: Create MariaDB Container
+      run: docker run --rm -d --name mariadb -e "MYSQL_ROOT_PASSWORD=Password12!" -e "MYSQL_DATABASE=sqlectron" -p 3306:3306 -v ${GITHUB_WORKSPACE}/spec/databases/mysql/schema:/docker-entrypoint-initdb.d mariadb:${{ matrix.mysql-version }}
     - name: Create Postgres Container
       run: docker run --rm -d --name postgres -e "POSTGRES_PASSWORD=Password12!" -e "POSTGRES_DB=sqlectron" -p 5432:5432 -v ${GITHUB_WORKSPACE}/spec/databases/postgresql/schema:/docker-entrypoint-initdb.d postgres:${{ matrix.postgres-version }}
     - name: Create Cassandra Container

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,4 +105,4 @@ jobs:
     - name: Initialize SQLServer Schema
       run: docker exec -i sqlserver /opt/mssql-tools/bin/sqlcmd -S localhost,1433 -U sa -P Password12! -i /docker-entrypoint-initdb.d/schema.sql -d "sqlectron"
 
-    - run: DB_CLIENTS=mysql,postgresql,sqlite,sqlserver,cassandra npm run test:coverage
+    - run: DB_CLIENTS=mysql,mariadb,postgresql,sqlite,sqlserver,cassandra npm run test:coverage

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prepublishOnly": "npm run compile",
     "lint": "eslint src/ spec/",
     "test:mysql": "DB_CLIENTS=mysql npm run test",
+    "test:mariadb": "DB_CLIENTS=mariadb npm run test",
     "test:sqlite": "DB_CLIENTS=sqlite npm run test",
     "test:sqlserver": "DB_CLIENTS=sqlserver npm run test",
     "test:postgresql": "DB_CLIENTS=postgresql npm run test",

--- a/spec/databases/config.js
+++ b/spec/databases/config.js
@@ -17,6 +17,14 @@ export default {
     database: process.env.MYSQL_ENV_MYSQL_DATABASE,
     multipleStatements: true,
   },
+  mariadb: {
+    host: url.parse(process.env.MARIADB_PORT || '').hostname,
+    port: parseInt(url.parse(process.env.MARIADB_PORT || '').port, 10),
+    user: process.env.MARIADB_ENV_MARIADB_USER,
+    password: process.env.MARIADB_ENV_MARIADB_PASSWORD,
+    database: process.env.MARIADB_ENV_MARIADB_DATABASE,
+    multipleStatements: true,
+  },
   sqlserver: {
     host: process.env.SQLSERVER_ENV_SQLSERVER_HOST,
     port: parseInt(process.env.SQLSERVER_ENV_SQLSERVER_PORT, 10),

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -155,7 +155,7 @@ describe('db', () => {
               expect(routines).to.have.length(2);
               expect(routine).to.have.deep.property('routineType').to.eql('FUNCTION');
               expect(routine).to.have.deep.property('schema').to.eql(dbSchema);
-            } else if (dbClient === 'mysql') {
+            } else if (dbClient === 'mysql' || dbClient === 'mariadb') {
               expect(routines).to.have.length(1);
               expect(routine).to.have.deep.property('routineType').to.eql('PROCEDURE');
               expect(routine).to.not.have.deep.property('schema');
@@ -244,7 +244,7 @@ describe('db', () => {
             } else if (dbClient === 'postgresql') {
               expect(indexes).to.have.length(1);
               expect(indexes).to.include.members(['users_pkey']);
-            } else if (dbClient === 'mysql') {
+            } else if (dbClient === 'mysql' || dbClient === 'mariadb') {
               expect(indexes).to.have.length(2);
               expect(indexes).to.include.members(['PRIMARY', 'role_id']);
             } else if (dbClient === 'sqlserver') {
@@ -322,7 +322,7 @@ describe('db', () => {
               '  KEY `role_id` (`role_id`),\n' +
               '  CONSTRAINT `users_ibfk_1` FOREIGN KEY (`role_id`) REFERENCES `roles` (`id`) ON DELETE CASCADE\n' +
               ') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci');
-            } else if (dbClient === 'mysql') {
+            } else if (dbClient === 'mysql' || dbClient === 'mariadb') {
               expect(createScript).to.contain('CREATE TABLE `users` (\n' +
                 '  `id` int(11) NOT NULL AUTO_INCREMENT,\n' +
                 '  `username` varchar(45) DEFAULT NULL,\n' +
@@ -379,7 +379,7 @@ describe('db', () => {
         describe('.getTableSelectScript', () => {
           it('should return SELECT table script', async () => {
             const selectQuery = await dbConn.getTableSelectScript('users');
-            if (dbClient === 'mysql') {
+            if (dbClient === 'mysql' || dbClient === 'mariadb') {
               expect(selectQuery).to.eql('SELECT `id`, `username`, `email`, `password`, `role_id`, `createdat` FROM `users`;');
             } else if (dbClient === 'sqlserver') {
               expect(selectQuery).to.eql('SELECT [id], [username], [email], [password], [role_id], [createdat] FROM [users];');
@@ -406,7 +406,7 @@ describe('db', () => {
         describe('.getTableInsertScript', () => {
           it('should return INSERT INTO table script', async () => {
             const insertQuery = await dbConn.getTableInsertScript('users');
-            if (dbClient === 'mysql') {
+            if (dbClient === 'mysql' || dbClient === 'mariadb') {
               expect(insertQuery).to.eql([
                 'INSERT INTO `users` (`id`, `username`, `email`, `password`, `role_id`, `createdat`)\n',
                 'VALUES (?, ?, ?, ?, ?, ?);',
@@ -450,7 +450,7 @@ describe('db', () => {
         describe('.getTableUpdateScript', () => {
           it('should return UPDATE table script', async () => {
             const updateQuery = await dbConn.getTableUpdateScript('users');
-            if (dbClient === 'mysql') {
+            if (dbClient === 'mysql' || dbClient === 'mariadb') {
               expect(updateQuery).to.eql([
                 'UPDATE `users`\n',
                 'SET `id`=?, `username`=?, `email`=?, `password`=?, `role_id`=?, `createdat`=?\n',
@@ -500,7 +500,7 @@ describe('db', () => {
         describe('.getTableDeleteScript', () => {
           it('should return table DELETE script', async () => {
             const deleteQuery = await dbConn.getTableDeleteScript('roles');
-            if (dbClient === 'mysql') {
+            if (dbClient === 'mysql' || dbClient === 'mariadb') {
               expect(deleteQuery).to.contain('DELETE FROM `roles` WHERE <condition>;');
             } else if (dbClient === 'sqlserver') {
               expect(deleteQuery).to.contain('DELETE FROM [roles] WHERE <condition>;');
@@ -527,7 +527,7 @@ describe('db', () => {
           it('should return CREATE VIEW script', async () => {
             const [createScript] = await dbConn.getViewCreateScript('email_view');
 
-            if (dbClient === 'mysql') {
+            if (dbClient === 'mysql' || dbClient === 'mariadb') {
               expect(createScript).to.contain([
                 'VIEW `email_view`',
                 'AS select `users`.`email` AS `email`,`users`.`password` AS `password`',
@@ -564,7 +564,7 @@ describe('db', () => {
           it('should return CREATE PROCEDURE/FUNCTION script', async () => {
             const [createScript] = await dbConn.getRoutineCreateScript('users_count', 'Procedure');
 
-            if (dbClient === 'mysql') {
+            if (dbClient === 'mysql' || dbClient === 'mariadb') {
               expect(createScript).to.contain('CREATE DEFINER=');
               expect(createScript).to.contain([
                 'PROCEDURE `users_count`()',
@@ -601,6 +601,7 @@ describe('db', () => {
               const sleepCommands = {
                 postgresql: 'SELECT pg_sleep(10);',
                 mysql: 'SELECT SLEEP(10000);',
+                mariadb: 'SELECT SLEEP(10000;',
                 sqlserver: 'WAITFOR DELAY \'00:00:10\'; SELECT 1 AS number',
                 sqlite: '',
               };
@@ -681,7 +682,7 @@ describe('db', () => {
                 const results = await dbConn.executeQuery('-- my comment');
 
                 // MySQL treats commented query as a non select query
-                if (dbClient === 'mysql') {
+                if (dbClient === 'mysql' || dbClient === 'mariadb') {
                   expect(results).to.have.length(1);
                 } else {
                   expect(results).to.have.length(0);
@@ -748,7 +749,7 @@ describe('db', () => {
               expect(result).to.have.deep.property('rowCount').to.eql(1);
             });
 
-            if (dbClient === 'mysql' || dbClient === 'postgresql') {
+            if (dbClient === 'mysql' || dbClient === 'postgresql' || dbClient === 'mariadb') {
               it('should not cast DATE types to native JS Date objects', async () => {
                 const results = await dbConn.executeQuery('select createdat from users');
 

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -601,7 +601,7 @@ describe('db', () => {
               const sleepCommands = {
                 postgresql: 'SELECT pg_sleep(10);',
                 mysql: 'SELECT SLEEP(10000);',
-                mariadb: 'SELECT SLEEP(10000;',
+                mariadb: 'SELECT SLEEP(10000);',
                 sqlserver: 'WAITFOR DELAY \'00:00:10\'; SELECT 1 AS number',
                 sqlite: '',
               };

--- a/src/db/clients/index.js
+++ b/src/db/clients/index.js
@@ -19,6 +19,15 @@ export const CLIENTS = [
     ],
   },
   {
+    key: 'mariadb',
+    name: 'MariaDB',
+    defaultPort: 3306,
+    disabledFeatures: [
+      'server:schema',
+      'server:domain',
+    ],
+  },
+  {
     key: 'postgresql',
     name: 'PostgreSQL',
     defaultDatabase: 'postgres',
@@ -68,6 +77,7 @@ export const CLIENTS = [
 
 export default {
   mysql,
+  mariadb: mysql,
   postgresql,
   sqlserver,
   sqlite,


### PR DESCRIPTION
The mariadb client acts as a full drop-in replacement for mysql. While users could select mysql in the client dropdown in sqlectron-gui, it's a bit nicer experience to present it as an option for those that do not realize it's a straight drop-in replacement.