### PR TITLE
fix version query breaking on redshift

### DIFF
--- a/src/db/clients/postgresql.js
+++ b/src/db/clients/postgresql.js
@@ -33,7 +33,7 @@ export default async function (server, database) {
   logger().debug('connected');
   const defaultSchema = await getSchema(conn);
 
-  const version = (await driverExecuteQuery(conn, { query: 'SHOW server_version;' })).rows[0].server_version;
+  const version = (await driverExecuteQuery(conn, { query: 'select version()' })).rows[0].version;
 
   return {
     /* eslint max-len:0 */


### PR DESCRIPTION
`SHOW server_version` was something added in 9.x (I think?) and so does not work for redshift which is based off postgres 8.