### PR TITLE
Use DSN connection strings for defining test database details

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,28 +45,12 @@ jobs:
             sqlserver-collation: Latin1_General_CS_AS
 
     env:
-      CASSANDRA_PORT: tcp://localhost:9042
-      POSTGRES_PORT: tcp://localhost:5432
-      POSTGRES_ENV_POSTGRES_USER: postgres
-      POSTGRES_ENV_POSTGRES_PASSWORD: Password12!
-      POSTGRES_ENV_POSTGRES_DB: sqlectron
-      PGUSER: postgres
-      PGPASSWORD: Password12!
-      MYSQL_PORT: tcp://localhost:3306
-      MYSQL_ENV_MYSQL_USER: root
-      MYSQL_ENV_MYSQL_PASSWORD: Password12!
-      MYSQL_ENV_MYSQL_DATABASE: sqlectron
-      MYSQL_PWD: Password12!
-      MARIADB_PORT: tcp://localhost:3307
-      MARIADB_ENV_MARIADB_USER: root
-      MARIADB_ENV_MARIADB_PASSWORD: Password12!
-      MARIADB_ENV_MARIADB_DATABASE: sqlectron
-      MARIADB_PWD: Password12!
-      SQLSERVER_ENV_SQLSERVER_HOST: localhost
-      SQLSERVER_ENV_SQLSERVER_PORT: 1433
-      SQLSERVER_ENV_SQLSERVER_USER: sa
-      SQLSERVER_ENV_SQLSERVER_PASSWORD: Password12!
-      SQLSERVER_ENV_SQLSERVER_DATABASE: sqlectron
+      CASSANDRA_DSN: cassandra://localhost:9042
+      POSTGRES_DSN: postgres://postgres:Password12!@localhost:5432/?dbname=sqlectron
+      MYSQL_DSN: mysql://root:Password12!@localhost:3306/?dbname=sqlectron
+      MARIADB_DSN: mysql://root:Password12!@localhost:3307/?dbname=sqlectron
+      SQLSERVER_DSN: sqlserver://sa:Password12!@localhost:1433/?dbname=sqlectron
+      SQLITE_DSN: sqlite:/tmp/sqlite/sqlectron.sqlite3
 
     steps:
     - uses: actions/checkout@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1187,6 +1187,12 @@
         "typedarray": "^0.0.6"
       }
     },
+    "connection-string": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/connection-string/-/connection-string-3.4.2.tgz",
+      "integrity": "sha512-t6LmVNKVn6ynMHewmTDxP+D+Rxt/Tx86KvUilPPTAYgJlVOMWcOJO01J6pu7qnwfOZru2ynsUETF44bTrggaHg==",
+      "dev": true
+    },
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "babel-eslint": "^10.1.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
+    "connection-string": "^3.4.2",
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^11.3.2",
     "eslint-plugin-import": "^2.20.2",

--- a/spec/databases/config.js
+++ b/spec/databases/config.js
@@ -1,43 +1,63 @@
-import url from 'url';
 import path from 'path';
+import { ConnectionString } from 'connection-string';
 
-export default {
-  postgresql: {
-    host: url.parse(process.env.POSTGRES_PORT || '').hostname,
-    port: parseInt(url.parse(process.env.POSTGRES_PORT || '').port, 10),
-    user: process.env.POSTGRES_ENV_POSTGRES_USER,
-    password: process.env.POSTGRES_ENV_POSTGRES_PASSWORD,
-    database: process.env.POSTGRES_ENV_POSTGRES_DB,
-  },
-  mysql: {
-    host: url.parse(process.env.MYSQL_PORT || '').hostname,
-    port: parseInt(url.parse(process.env.MYSQL_PORT || '').port, 10),
-    user: process.env.MYSQL_ENV_MYSQL_USER,
-    password: process.env.MYSQL_ENV_MYSQL_PASSWORD,
-    database: process.env.MYSQL_ENV_MYSQL_DATABASE,
-    multipleStatements: true,
-  },
-  mariadb: {
-    host: url.parse(process.env.MARIADB_PORT || '').hostname,
-    port: parseInt(url.parse(process.env.MARIADB_PORT || '').port, 10),
-    user: process.env.MARIADB_ENV_MARIADB_USER,
-    password: process.env.MARIADB_ENV_MARIADB_PASSWORD,
-    database: process.env.MARIADB_ENV_MARIADB_DATABASE,
-    multipleStatements: true,
-  },
-  sqlserver: {
-    host: process.env.SQLSERVER_ENV_SQLSERVER_HOST,
-    port: parseInt(process.env.SQLSERVER_ENV_SQLSERVER_PORT, 10),
-    user: process.env.SQLSERVER_ENV_SQLSERVER_USER,
-    password: process.env.SQLSERVER_ENV_SQLSERVER_PASSWORD,
-    database: process.env.SQLSERVER_ENV_SQLSERVER_DATABASE,
-  },
+const dbs = {
   sqlite: {
     database: path.join(__dirname, 'sqlite', 'sqlectron.db'),
   },
-  cassandra: {
-    host: url.parse(process.env.CASSANDRA_PORT || '').hostname,
-    port: 9042,
-    database: 'sqlectron',
-  },
 };
+
+if (process.env.POSTGRES_DSN) {
+  const postgres = new ConnectionString(process.env.POSTGRES_DSN);
+  dbs.postgresql = {
+    host: postgres.hosts[0].name,
+    port: postgres.hosts[0].port || 5432,
+    user: postgres.user || 'postgres',
+    password: postgres.password || '',
+    database: postgres.params.dbname || 'sqlectron',
+  };
+}
+
+if (process.env.MYSQL_DSN) {
+  const mysql = new ConnectionString(process.env.MYSQL_DSN);
+  dbs.mysql = {
+    host: mysql.hosts[0].name,
+    port: mysql.hosts[0].port || 3306,
+    user: mysql.user || 'root',
+    password: mysql.password || '',
+    database: mysql.params.dbname || 'sqlectron',
+  };
+}
+
+if (process.env.MARIADB_DSN) {
+  const mariadb = new ConnectionString(process.env.MARIADB_DSN);
+  dbs.mariadb = {
+    host: mariadb.hosts[0].name,
+    port: mariadb.hosts[0].port || 3306,
+    user: mariadb.user || 'root',
+    password: mariadb.password || '',
+    database: mariadb.params.dbname || 'sqlectron',
+  };
+}
+
+if (process.env.SQLSERVER_DSN) {
+  const sqlserver = new ConnectionString(process.env.SQLSERVER_DSN);
+  dbs.sqlserver = {
+    host: sqlserver.hosts[0].name,
+    port: sqlserver.hosts[0].port || 1433,
+    user: sqlserver.user || 'sa',
+    password: sqlserver.password || '',
+    database: sqlserver.params.dbname || 'sqlectron,',
+  };
+}
+
+if (process.env.CASSANDRA_DSN) {
+  const cassandra = new ConnectionString(process.env.CASSANDRA_DSN);
+  dbs.cassandra = {
+    host: cassandra.hosts[0].name,
+    port: cassandra.hosts[0].port || 9042,
+    database: cassandra.params ? cassandra.params.dbname || 'sqlectron' : 'sqlectron',
+  };
+}
+
+export default dbs;

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -31,9 +31,10 @@ describe('db', () => {
     throw new Error('Invalid selected db client for tests');
   }
 
-  if (~dbClients.indexOf('sqlite')) {
+  if (dbClients.includes('sqlite')) {
     setupSQLite(config.sqlite);
-  } else if (~dbClients.indexOf('cassandra')) {
+  }
+  if (dbClients.includes('cassandra')) {
     setupCassandra(config.cassandra);
   }
 


### PR DESCRIPTION
Simplifies the number of system variables necessary to test against a specific database. Further defaults may be added in a future PR as needed.