### PR TITLE
add version_compare utility function

### DIFF
--- a/spec/utils.spec.js
+++ b/spec/utils.spec.js
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+import { versionCompare } from '../src/utils';
+
+describe('utils', () => {
+  describe('.versionCompare', () => {
+    [
+      ['8.0.2', '8.0.1', 1],
+      ['8.0.2', '8.0.3', -1],
+      ['8.0.2.', '8.1', -1],
+      ['8.0.2', '8', 0],
+      ['8.0', '8', 0],
+      ['8', '8', 0],
+      ['8', '8.0.2', 0],
+      ['8', '8.0', 0],
+      ['8.0.2', '12.3', -1],
+      ['12.3', '8', 1],
+      ['12', '8', 1],
+      ['8', '12', -1],
+    ].forEach(([versionA, versionB, expected]) => {
+      it(`.versionCompare('${versionA}', '${versionB}') === ${expected}`, () => {
+        expect(versionCompare(versionA, versionB)).to.be.eql(expected);
+      });
+    });
+  });
+});

--- a/src/utils.js
+++ b/src/utils.js
@@ -146,3 +146,29 @@ export function createCancelablePromise(error, timeIdle = 100) {
     },
   };
 }
+
+/**
+ * Compares two version strings.
+ *
+ * For two version strings, this fucntion will return -1 if the first version is smaller
+ * than the second version, 0 if they are equal, and 1 if the second version is smaller.
+ * However, this function will only compare up-to the smallest part of the version string
+ * defined between the two, such '8' and '8.0.2' will be considered equal.
+ *
+ * @param {string} a
+ * @param {string} b
+ * @returns {boolean}
+ */
+export function versionCompare(a, b) {
+  const fullA = a.split('.').map((val) => parseInt(val, 10));
+  const fullB = b.split('.').map((val) => parseInt(val, 10));
+
+  for (let i = 0; i < Math.min(fullA.length, fullB.length); i++) {
+    if (fullA[i] > fullB[i]) {
+      return 1;
+    } else if (fullA[i] < fullB[i]) {
+      return -1;
+    }
+  }
+  return 0;
+}


### PR DESCRIPTION
This provides a simplistic version_compare function, which will
be necessary for follow-up work where need to run different queries
depending on the version the client is running on. This will be done
in conjuction with another PR which adds a uniform "getVersion()"
function to all clients which will provide the same object structure
to make version comparison easy.

Signed-off-by: Matthew Peveler <matt.peveler@gmail.com>