### PR TITLE
fix docker-compose not following current official schema

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,43 +1,56 @@
-mysql:
-  image: mysql:5.7
-  ports:
-    - 3306
-  environment:
-    MYSQL_ROOT_PASSWORD: password
-    MYSQL_DATABASE: sqlectron
-  volumes:
-    - ./spec/databases/mysql/schema:/docker-entrypoint-initdb.d
+version: '3'
 
-postgres:
-  image: postgres:9.4.5
-  ports:
-    - 5432
-  environment:
-    POSTGRES_USER: user
-    POSTGRES_PASSWORD: password
-    POSTGRES_DB: sqlectron
-  volumes:
-    - ./spec/databases/postgresql/schema:/docker-entrypoint-initdb.d
+services:
+  mysql:
+    image: mysql:5.7
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: sqlectron
+    volumes:
+      - ./spec/databases/mysql/schema:/docker-entrypoint-initdb.d
 
-cassandra:
-  image: cassandra:3.7
-  environment:
-    JVM_OPTS: -Xms128m -Xmx512m
-  ports:
-    - 7000 # cluster
-    - 9042 # native
+  mariadb:
+    image: mariadb:10.1
+    ports:
+      - 3307:3306
+    environment:
+      MYSQL_DATABASE: sqlectron
+      MYSQL_ROOT_PASSWORD: sqlectron
+    volumes:
+      - ./spec/databases/mysql/schema:/docker-entrypoint-initdb.d
 
-test:
-  image: node:10.15.0
-  command: npm test
-  working_dir: /usr/src/app
-  environment:
-    DB_CLIENTS: mysql,postgresql,cassandra
-    MYSQL_ENV_MYSQL_USER: root
-    MYSQL_ENV_MYSQL_PASSWORD: password
-  volumes:
-    - .:/usr/src/app
-  links:
-    - mysql:mysql
-    - postgres:postgres
-    - cassandra:cassandra
+  postgres:
+    image: postgres:9.4.5
+    ports:
+      - 5432
+    environment:
+      POSTGRES_USER: sqlectron
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: sqlectron
+    volumes:
+      - ./spec/databases/postgresql/schema:/docker-entrypoint-initdb.d
+
+  cassandra:
+    image: cassandra:3.7
+    environment:
+      JVM_OPTS: -Xms128m -Xmx512m
+    ports:
+      - 7000 # cluster
+      - 9042 # native
+
+  test:
+    image: node:10.15.0
+    command: npm test
+    working_dir: /usr/src/app
+    environment:
+      DB_CLIENTS: mysql,postgresql,cassandra
+      MYSQL_ENV_MYSQL_USER: root
+      MYSQL_ENV_MYSQL_PASSWORD: password
+    volumes:
+      - .:/usr/src/app
+    links:
+      - mysql:mysql
+      - postgres:postgres
+      - cassandra:cassandra


### PR DESCRIPTION
The file was using an older schema specification, which while it worked, it would break on the schema validation provided by [vscode-yaml](https://github.com/redhat-developer/vscode-yaml) extension. This PR moves it to use the version 3 schema, and by extension be validated via the above extension again for local development.