### PR TITLE
Add getVersion function to db clients to get version details

### DIFF
--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -93,7 +93,14 @@ describe('db', () => {
         });
 
         describe('.version', () => {
-          it('should return a version', async () => {
+          it('should return version string', () => {
+            const version = dbConn.version();
+            expect(version).to.be.a.string.and.not.be.empty;
+          });
+        });
+
+        describe('.getVersion', () => {
+          it('should return version details', () => {
             const version = dbConn.getVersion();
             console.log(version);
             expect(dbConn.getVersion()).to.be.a('object');

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -96,7 +96,7 @@ describe('db', () => {
         describe('.version', () => {
           it('should return version string', () => {
             const version = dbConn.version();
-            expect(version).to.be.a.string.and.not.be.empty;
+            expect(version).to.be.a('string').and.not.be.empty;
           });
         });
 

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -4,6 +4,7 @@ import { db } from '../src';
 import config from './databases/config';
 import setupSQLite from './databases/sqlite/setup';
 import setupCassandra from './databases/cassandra/setup';
+import { versionCompare } from '../src/utils';
 
 chai.use(chaiAsPromised);
 
@@ -102,7 +103,6 @@ describe('db', () => {
         describe('.getVersion', () => {
           it('should return version details', () => {
             const version = dbConn.getVersion();
-            console.log(version);
             expect(dbConn.getVersion()).to.be.a('object');
             const expectedName = {
               postgres: 'PostgreSQL',
@@ -328,7 +328,7 @@ describe('db', () => {
           it('should return table create script', async () => {
             const [createScript] = await dbConn.getTableCreateScript('users');
 
-            if (dbClient === 'mysql' && parseInt(dbConn.version()[0], 10) >= '8') {
+            if (dbClient === 'mysql' && versionCompare(dbConn.getVersion().version, '8') >= 0) {
               expect(createScript).to.contain('CREATE TABLE `users` (\n' +
               '  `id` int NOT NULL AUTO_INCREMENT,\n' +
               '  `username` varchar(45) DEFAULT NULL,\n' +
@@ -706,7 +706,7 @@ describe('db', () => {
                 }
               } catch (err) {
                 if (dbClient === 'cassandra') {
-                  if (dbConn.version().split('.')[0] === '2') {
+                  if (versionCompare(dbConn.getVersion().version, '2') === 0) {
                     expect(err.message).to.eql('line 0:-1 no viable alternative at input \'<EOF>\'');
                   } else {
                     expect(err.message).to.eql('line 1:13 mismatched character \'<EOF>\' expecting set null');
@@ -811,7 +811,7 @@ describe('db', () => {
                 expect(secondResult).to.have.deep.property('rowCount').to.eql(1);
               } catch (err) {
                 if (dbClient === 'cassandra') {
-                  if (parseFloat(dbConn.version().split('.').slice(0, 2).join('.')) >= 3.10) {
+                  if (versionCompare(dbConn.getVersion().version, '3.10') >= 0) {
                     expect(err.message).to.match(/mismatched input 'select' expecting EOF/);
                   } else {
                     expect(err.message).to.match(/missing EOF at 'select'/);
@@ -891,7 +891,7 @@ describe('db', () => {
                 }
               } catch (err) {
                 if (dbClient === 'cassandra') {
-                  if (parseFloat(dbConn.version().split('.').slice(0, 2).join('.')) >= 3.10) {
+                  if (versionCompare(dbConn.getVersion().version, '3.10') >= 0) {
                     expect(err.message).to.match(/mismatched input 'insert' expecting EOF/);
                   } else {
                     expect(err.message).to.match(/missing EOF at 'insert'/);
@@ -967,7 +967,7 @@ describe('db', () => {
                 }
               } catch (err) {
                 if (dbClient === 'cassandra') {
-                  if (parseFloat(dbConn.version().split('.').slice(0, 2).join('.')) >= 3.10) {
+                  if (versionCompare(dbConn.getVersion().version, '3.10') >= 0) {
                     expect(err.message).to.match(/mismatched input 'delete' expecting EOF/);
                   } else {
                     expect(err.message).to.match(/missing EOF at 'delete'/);
@@ -1043,7 +1043,7 @@ describe('db', () => {
                 }
               } catch (err) {
                 if (dbClient === 'cassandra') {
-                  if (parseFloat(dbConn.version().split('.').slice(0, 2).join('.')) >= 3.10) {
+                  if (versionCompare(dbConn.version().version, '3.10') >= 0) {
                     expect(err.message).to.match(/mismatched input 'update' expecting EOF/);
                   } else {
                     expect(err.message).to.match(/missing EOF at 'update'/);

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -105,7 +105,7 @@ describe('db', () => {
             const version = dbConn.getVersion();
             expect(dbConn.getVersion()).to.be.a('object');
             const expectedName = {
-              postgres: 'PostgreSQL',
+              postgresql: 'PostgreSQL',
               mysql: 'MySQL',
               mariadb: 'MariaDB',
               sqlite: 'SQLite',
@@ -113,7 +113,7 @@ describe('db', () => {
               cassandra: 'Cassandra',
             };
             expect(version).to.have.property('name').to.contain(expectedName[dbClient]);
-            expect(version).to.have.property('version').to.be.a('string').and.to.match(/(?:[0-9]\.)+/);
+            expect(version).to.have.property('version').to.be.a('string').and.to.match(/(?:[0-9]\.?)+/);
             expect(version).to.have.property('string').to.be.a('string').and.to.be.not.empty;
           });
         });
@@ -1045,7 +1045,7 @@ describe('db', () => {
                 }
               } catch (err) {
                 if (dbClient === 'cassandra') {
-                  if (versionCompare(dbConn.version().version, '3.10') >= 0) {
+                  if (versionCompare(dbConn.getVersion().version, '3.10') >= 0) {
                     expect(err.message).to.match(/mismatched input 'update' expecting EOF/);
                   } else {
                     expect(err.message).to.match(/missing EOF at 'update'/);

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -94,8 +94,18 @@ describe('db', () => {
 
         describe('.version', () => {
           it('should return a version', async () => {
-            expect(dbConn.version()).to.be.a('string');
-            expect(dbConn.version()).to.not.be.empty;
+            const version = dbConn.getVersion();
+            console.log(version);
+            expect(dbConn.getVersion()).to.be.a('object');
+            const expectedName = {
+              postgres: 'PostgreSQL',
+              mysql: 'MySQL',
+              mariadb: 'MariaDB',
+              sqlite: 'SQLite',
+            };
+            expect(version).to.have.property('name').to.contain(expectedName[dbClient]);
+            expect(version).to.have.property('version').to.be.a('string').and.to.match(/(?:[0-9]\.)+/);
+            expect(version).to.have.property('string').to.be.a('string').and.to.be.not.empty;
           });
         });
 

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -109,6 +109,8 @@ describe('db', () => {
               mysql: 'MySQL',
               mariadb: 'MariaDB',
               sqlite: 'SQLite',
+              sqlserver: 'SQL Server',
+              cassandra: 'Cassandra',
             };
             expect(version).to.have.property('name').to.contain(expectedName[dbClient]);
             expect(version).to.have.property('version').to.be.a('string').and.to.match(/(?:[0-9]\.)+/);

--- a/src/db/client.js
+++ b/src/db/client.js
@@ -18,7 +18,7 @@ export function createConnection(server, database) {
   return {
     connect: connect.bind(null, server, database),
     disconnect: disconnect.bind(null, server, database),
-    version: version.bind(null, server, database),
+    getVersion: getVersion.bind(null, server, database),
     listTables: listTables.bind(null, server, database),
     listViews: listViews.bind(null, server, database),
     listRoutines: listRoutines.bind(null, server, database),
@@ -120,9 +120,9 @@ function disconnect(server, database) {
   }
 }
 
-function version(server, database) {
+function getVersion(server, database) {
   checkIsConnected(server, database);
-  return database.connection.version;
+  return database.connection.getVersion();
 }
 
 function listSchemas(server, database, filter) {

--- a/src/db/client.js
+++ b/src/db/client.js
@@ -18,6 +18,7 @@ export function createConnection(server, database) {
   return {
     connect: connect.bind(null, server, database),
     disconnect: disconnect.bind(null, server, database),
+    version: version.bind(null, server, database),
     getVersion: getVersion.bind(null, server, database),
     listTables: listTables.bind(null, server, database),
     listViews: listViews.bind(null, server, database),
@@ -118,6 +119,14 @@ function disconnect(server, database) {
   if (server.db[database.database]) {
     delete server.db[database.database];
   }
+}
+
+/**
+ * @deprecated
+ */
+function version(server, database) {
+  checkIsConnected(server, database);
+  return database.connection.version;
 }
 
 function getVersion(server, database) {

--- a/src/db/clients/cassandra.js
+++ b/src/db/clients/cassandra.js
@@ -23,12 +23,13 @@ export default function (server, database) {
         return reject(err);
       }
 
-      client.version = client.getState().getConnectedHosts()[0].cassandraVersion;
+      client.version = client.getState().getConnectedHosts()[0].getCassandraVersion();
 
       logger().debug('connected');
       resolve({
         wrapIdentifier,
-        version: client.version,
+        version: client.getState().getConnectedHosts()[0].cassandraVersion,
+        getVersion: () => client.getState().getConnectedHosts()[0].cassandraVersion,
         disconnect: () => disconnect(client),
         listTables: (db) => listTables(client, db),
         listViews: () => listViews(client),
@@ -60,7 +61,7 @@ export function disconnect(client) {
 export function listTables(client, database) {
   return new Promise((resolve, reject) => {
     let sql;
-    if (client.version.split('.')[0] === '2') {
+    if (client.version[0] === 2) {
       sql = `
         SELECT columnfamily_name as name
         FROM system.schema_columnfamilies
@@ -91,7 +92,7 @@ export function listRoutines() {
 }
 
 export function listTableColumns(client, database, table) {
-  const cassandra2 = client.version.split('.')[0] === '2';
+  const cassandra2 = client.version[0] === 2;
   return new Promise((resolve, reject) => {
     let sql;
     if (cassandra2) {

--- a/src/db/clients/cassandra.js
+++ b/src/db/clients/cassandra.js
@@ -25,7 +25,7 @@ export default function (server, database) {
 
       client.version = client.getState().getConnectedHosts()[0].getCassandraVersion();
 
-      const versionData = {
+      client.versionData = {
         name: 'Cassandra',
         version: client.getState().getConnectedHosts()[0].cassandraVersion,
         string: `Cassandra ${client.getState().getConnectedHosts()[0].cassandraVersion}`,
@@ -35,7 +35,7 @@ export default function (server, database) {
       resolve({
         wrapIdentifier,
         version: client.getState().getConnectedHosts()[0].cassandraVersion,
-        getVersion: () => versionData,
+        getVersion: () => client.versionData,
         disconnect: () => disconnect(client),
         listTables: (db) => listTables(client, db),
         listViews: () => listViews(client),

--- a/src/db/clients/cassandra.js
+++ b/src/db/clients/cassandra.js
@@ -25,11 +25,17 @@ export default function (server, database) {
 
       client.version = client.getState().getConnectedHosts()[0].getCassandraVersion();
 
+      const versionData = {
+        name: 'Cassandra',
+        version: client.getState().getConnectedHosts()[0].cassandraVersion,
+        string: `Cassandra ${client.getState().getConnectedHosts()[0].cassandraVersion}`,
+      };
+
       logger().debug('connected');
       resolve({
         wrapIdentifier,
         version: client.getState().getConnectedHosts()[0].cassandraVersion,
-        getVersion: () => client.getState().getConnectedHosts()[0].cassandraVersion,
+        getVersion: () => versionData,
         disconnect: () => disconnect(client),
         listTables: (db) => listTables(client, db),
         listViews: () => listViews(client),

--- a/src/db/clients/mysql.js
+++ b/src/db/clients/mysql.js
@@ -21,12 +21,27 @@ export default async function (server, database) {
     pool: mysql.createPool(dbConfig),
   };
 
-  // light solution to test connection with with the server
-  const version = (await driverExecuteQuery(conn, { query: 'select version() as version;' })).data[0].version;
+  const versionInfo = (await driverExecuteQuery(conn, { query: "SHOW VARIABLES WHERE variable_name='version' OR variable_name='version_comment';" })).data;
+  const versionData = {
+    name: '',
+    version: '',
+    string: '',
+  };
+
+  for (let i = 0; i < versionInfo.length; i++) {
+    const item = versionInfo[i];
+    if (item.Variable_name === 'version') {
+      versionData.version = item.Value;
+    } else if (item.Variable_name === 'version_comment') {
+      versionData.name = item.Value;
+    }
+  }
+  versionData.string = `${versionData.name} ${versionData.version}`;
+  versionData.version = versionData.version.split('-')[0];
 
   return {
     wrapIdentifier,
-    version,
+    getVersion: () => versionData,
     disconnect: () => disconnect(conn),
     listTables: () => listTables(conn),
     listViews: () => listViews(conn),

--- a/src/db/clients/mysql.js
+++ b/src/db/clients/mysql.js
@@ -41,6 +41,7 @@ export default async function (server, database) {
 
   return {
     wrapIdentifier,
+    version: versionData.version,
     getVersion: () => versionData,
     disconnect: () => disconnect(conn),
     listTables: () => listTables(conn),

--- a/src/db/clients/mysql.js
+++ b/src/db/clients/mysql.js
@@ -36,7 +36,7 @@ export default async function (server, database) {
     }
   }
 
-  const versionData = {
+  conn.versionData = {
     name: versionComment,
     version: version.split('-')[0],
     string: `${versionComment} ${version}`,
@@ -47,17 +47,17 @@ export default async function (server, database) {
   // "mariadb.org binary distribution"
   const lowerComment = versionComment.toLowerCase();
   if (lowerComment.includes('mysql')) {
-    versionData.name = 'MySQL';
+    conn.versionData.name = 'MySQL';
   } else if (lowerComment.includes('mariadb')) {
-    versionData.name = 'MariaDB';
+    conn.versionData.name = 'MariaDB';
   } else if (lowerComment.includes('percona')) {
-    versionData.name = 'Percona';
+    conn.versionData.name = 'Percona';
   }
 
   return {
     wrapIdentifier,
-    version: versionData.version,
-    getVersion: () => versionData,
+    version: conn.versionData.version,
+    getVersion: () => conn.versionData,
     disconnect: () => disconnect(conn),
     listTables: () => listTables(conn),
     listViews: () => listViews(conn),

--- a/src/db/clients/postgresql.js
+++ b/src/db/clients/postgresql.js
@@ -34,11 +34,17 @@ export default async function (server, database) {
   const defaultSchema = await getSchema(conn);
 
   const version = (await driverExecuteQuery(conn, { query: 'select version()' })).rows[0].version;
+  const splitVersion = version.split(' ');
+  const versionDetails = {
+    name: splitVersion[0],
+    version: splitVersion[1],
+    string: version,
+  };
 
   return {
     /* eslint max-len:0 */
     wrapIdentifier,
-    version,
+    getVersion: () => versionDetails,
     disconnect: () => disconnect(conn),
     listTables: (db, filter) => listTables(conn, filter),
     listViews: (filter) => listViews(conn, filter),

--- a/src/db/clients/postgresql.js
+++ b/src/db/clients/postgresql.js
@@ -44,6 +44,7 @@ export default async function (server, database) {
   return {
     /* eslint max-len:0 */
     wrapIdentifier,
+    version,
     getVersion: () => versionDetails,
     disconnect: () => disconnect(conn),
     listTables: (db, filter) => listTables(conn, filter),

--- a/src/db/clients/postgresql.js
+++ b/src/db/clients/postgresql.js
@@ -35,7 +35,8 @@ export default async function (server, database) {
 
   const version = (await driverExecuteQuery(conn, { query: 'select version()' })).rows[0].version;
   const splitVersion = version.split(' ');
-  const versionDetails = {
+
+  conn.versionData = {
     name: splitVersion[0],
     version: splitVersion[1],
     string: version,
@@ -45,7 +46,7 @@ export default async function (server, database) {
     /* eslint max-len:0 */
     wrapIdentifier,
     version,
-    getVersion: () => versionDetails,
+    getVersion: () => conn.versionData,
     disconnect: () => disconnect(conn),
     listTables: (db, filter) => listTables(conn, filter),
     listViews: (filter) => listViews(conn, filter),

--- a/src/db/clients/sqlite.js
+++ b/src/db/clients/sqlite.js
@@ -18,10 +18,15 @@ export default async function (server, database) {
 
   // light solution to test connection with with the server
   const version = (await driverExecuteQuery(conn, { query: 'SELECT sqlite_version() as version' })).data[0].version;
+  const versionData = {
+    name: 'SQLite',
+    version,
+    string: `SQLite ${version}`,
+  };
 
   return {
     wrapIdentifier,
-    version,
+    getVersion: () => versionData,
     disconnect: () => disconnect(conn),
     listTables: () => listTables(conn),
     listViews: () => listViews(conn),

--- a/src/db/clients/sqlite.js
+++ b/src/db/clients/sqlite.js
@@ -26,6 +26,7 @@ export default async function (server, database) {
 
   return {
     wrapIdentifier,
+    version,
     getVersion: () => versionData,
     disconnect: () => disconnect(conn),
     listTables: () => listTables(conn),

--- a/src/db/clients/sqlite.js
+++ b/src/db/clients/sqlite.js
@@ -18,7 +18,7 @@ export default async function (server, database) {
 
   // light solution to test connection with with the server
   const version = (await driverExecuteQuery(conn, { query: 'SELECT sqlite_version() as version' })).data[0].version;
-  const versionData = {
+  conn.versionData = {
     name: 'SQLite',
     version,
     string: `SQLite ${version}`,
@@ -27,7 +27,7 @@ export default async function (server, database) {
   return {
     wrapIdentifier,
     version,
-    getVersion: () => versionData,
+    getVersion: () => conn.versionData,
     disconnect: () => disconnect(conn),
     listTables: () => listTables(conn),
     listViews: () => listViews(conn),

--- a/src/db/clients/sqlserver.js
+++ b/src/db/clients/sqlserver.js
@@ -20,7 +20,7 @@ export default async function (server, database) {
   // light solution to test connection with with the server
   const version = (await driverExecuteQuery(conn, { query: 'SELECT @@version as \'version\'' })).data[0].version;
 
-  const versionData = {
+  conn.versionData = {
     name: 'SQL Server',
     version: version.match(/^Microsoft SQL Server ([0-9]{4})/)[1],
     string: version,
@@ -29,7 +29,7 @@ export default async function (server, database) {
   return {
     wrapIdentifier,
     version,
-    getVersion: () => versionData,
+    getVersion: () => conn.versionData,
     disconnect: () => disconnect(conn),
     listTables: (db, filter) => listTables(conn, filter),
     listViews: (filter) => listViews(conn, filter),

--- a/src/db/clients/sqlserver.js
+++ b/src/db/clients/sqlserver.js
@@ -20,10 +20,16 @@ export default async function (server, database) {
   // light solution to test connection with with the server
   const version = (await driverExecuteQuery(conn, { query: 'SELECT @@version as \'version\'' })).data[0].version;
 
+  const versionData = {
+    name: 'SQL Server',
+    version: version.match(/^Microsoft SQL Server ([0-9]{4})/)[1],
+    string: version,
+  };
+
   return {
     wrapIdentifier,
     version,
-    getVersion: () => version,
+    getVersion: () => versionData,
     disconnect: () => disconnect(conn),
     listTables: (db, filter) => listTables(conn, filter),
     listViews: (filter) => listViews(conn, filter),

--- a/src/db/clients/sqlserver.js
+++ b/src/db/clients/sqlserver.js
@@ -23,6 +23,7 @@ export default async function (server, database) {
   return {
     wrapIdentifier,
     version,
+    getVersion: () => version,
     disconnect: () => disconnect(conn),
     listTables: (db, filter) => listTables(conn, filter),
     listViews: (filter) => listViews(conn, filter),


### PR DESCRIPTION
This unifies aspects of getting version information across databases as prior to this. In #80, I added the `version` function that returns version details, except that this was inconsistent across providers where some would return just the version number string (e.g. `8.0.21`) and then some would return additional details (e.g. `PostgreSQL 9.4.26 on x86_64-pc-linux-gnu (Debian 9.4.26-1.pgdg90+1), compiled by gcc (Debian 6.3.0-18+deb9u1) 6.3.0 20170516, 64-bit`).

This deprecates the `version()` function in favor of `getVersion()` which returns an object that has the properties of `name`, `version`, and `string`. `name` is the minimal string name of the client (e.g. `PostgreSQL` or `MariaDB`), `version` is the numerical identifier (e.g. `9.4.26`), and then `string` is that full string.

This, combined with #100 cleans up some of the version comparisons in the test suite, as well as will be used in follow-up work for adding support for minimally redshift.