### PR TITLE
Simplify CI environment to match test config defaults

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,14 +44,6 @@ jobs:
             postgres-version: 9
             sqlserver-collation: Latin1_General_CS_AS
 
-    env:
-      CASSANDRA_DSN: cassandra://localhost:9042
-      POSTGRES_DSN: postgres://postgres:Password12!@localhost:5432/?dbname=sqlectron
-      MYSQL_DSN: mysql://root:Password12!@localhost:3306/?dbname=sqlectron
-      MARIADB_DSN: mysql://root:Password12!@localhost:3307/?dbname=sqlectron
-      SQLSERVER_DSN: sqlserver://sa:Password12!@localhost:1433/?dbname=sqlectron
-      SQLITE_DSN: sqlite:/tmp/sqlite/sqlectron.sqlite3
-
     steps:
     - uses: actions/checkout@v2
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - 3306:3306
     environment:
-      MYSQL_ROOT_PASSWORD: password
+      MYSQL_ROOT_PASSWORD: Password12!
       MYSQL_DATABASE: sqlectron
     volumes:
       - ./spec/databases/mysql/schema:/docker-entrypoint-initdb.d
@@ -16,8 +16,8 @@ services:
     ports:
       - 3307:3306
     environment:
+      MYSQL_ROOT_PASSWORD: Password12!
       MYSQL_DATABASE: sqlectron
-      MYSQL_ROOT_PASSWORD: sqlectron
     volumes:
       - ./spec/databases/mysql/schema:/docker-entrypoint-initdb.d
 
@@ -26,8 +26,7 @@ services:
     ports:
       - 5432
     environment:
-      POSTGRES_USER: sqlectron
-      POSTGRES_PASSWORD: password
+      POSTGRES_PASSWORD: Password12!
       POSTGRES_DB: sqlectron
     volumes:
       - ./spec/databases/postgresql/schema:/docker-entrypoint-initdb.d

--- a/spec/databases/config.js
+++ b/spec/databases/config.js
@@ -7,75 +7,74 @@ const dbs = {
   },
 };
 
-if (process.env.POSTGRES_DSN) {
-  const postgres = new ConnectionString(process.env.POSTGRES_DSN, {
-    user: 'postgres',
-    password: '',
-    path: ['sqlectron'],
-  });
-  dbs.postgresql = {
-    host: postgres.hostname,
-    port: postgres.port || 5432,
-    user: postgres.user,
-    password: postgres.password,
-    database: postgres.path && postgres.path[0],
-  };
-}
+const postgres = new ConnectionString(process.env.POSTGRES_DSN || '', {
+  protocol: 'postgres',
+  user: 'postgres',
+  password: 'Password12!',
+  path: ['sqlectron'],
+  hosts: [{ name: 'localhost', port: 5432 }],
+});
+dbs.postgresql = {
+  host: postgres.hostname,
+  port: postgres.port || 5432,
+  user: postgres.user,
+  password: postgres.password,
+  database: postgres.path && postgres.path[0],
+};
 
-if (process.env.MYSQL_DSN) {
-  const mysql = new ConnectionString(process.env.MYSQL_DSN, {
-    user: 'root',
-    password: '',
-    path: ['sqlectron'],
-  });
-  dbs.mysql = {
-    host: mysql.hostname,
-    port: mysql.port || 3306,
-    user: mysql.user,
-    password: mysql.password,
-    database: mysql.path && mysql.path[0],
-  };
-}
+const mysql = new ConnectionString(process.env.MYSQL_DSN || '', {
+  protocol: 'mysql',
+  user: 'root',
+  password: 'Password12!',
+  path: ['sqlectron'],
+  hosts: [{ name: 'localhost', port: 3306 }],
+});
+dbs.mysql = {
+  host: mysql.hostname,
+  port: mysql.port || 3306,
+  user: mysql.user,
+  password: mysql.password,
+  database: mysql.path && mysql.path[0],
+};
 
-if (process.env.MARIADB_DSN) {
-  const mariadb = new ConnectionString(process.env.MARIADB_DSN, {
-    user: 'root',
-    password: '',
-    path: ['sqlectron'],
-  });
-  dbs.mariadb = {
-    host: mariadb.hostname,
-    port: mariadb.port || 3306,
-    user: mariadb.user,
-    password: mariadb.password,
-    database: mariadb.path && mariadb.path[0],
-  };
-}
+const mariadb = new ConnectionString(process.env.MARIADB_DSN || '', {
+  user: 'root',
+  password: 'Password12!',
+  path: ['sqlectron'],
+  hosts: [{ name: 'localhost', port: 3307 }],
+});
+dbs.mariadb = {
+  host: mariadb.hostname,
+  port: mariadb.port || 3307,
+  user: mariadb.user,
+  password: mariadb.password,
+  database: mariadb.path && mariadb.path[0],
+};
 
-if (process.env.SQLSERVER_DSN) {
-  const sqlserver = new ConnectionString(process.env.SQLSERVER_DSN, {
-    user: 'sa',
-    password: '',
-    path: ['sqlectron'],
-  });
-  dbs.sqlserver = {
-    host: sqlserver.hostname,
-    port: sqlserver.port || 1433,
-    user: sqlserver.user,
-    password: sqlserver.password,
-    database: sqlserver.path && sqlserver.path[0],
-  };
-}
+const sqlserver = new ConnectionString(process.env.SQLSERVER_DSN || '', {
+  protocol: 'mssql',
+  user: 'sa',
+  password: 'Password12!',
+  path: ['sqlectron'],
+  hosts: [{ name: 'localhost', port: 1433 }],
+});
+dbs.sqlserver = {
+  host: sqlserver.hostname,
+  port: sqlserver.port || 1433,
+  user: sqlserver.user,
+  password: sqlserver.password,
+  database: sqlserver.path && sqlserver.path[0],
+};
 
-if (process.env.CASSANDRA_DSN) {
-  const cassandra = new ConnectionString(process.env.CASSANDRA_DSN, {
-    path: ['sqlectron'],
-  });
-  dbs.cassandra = {
-    host: cassandra.hostname,
-    port: cassandra.port || 9042,
-    database: cassandra.path && cassandra.path[0],
-  };
-}
+const cassandra = new ConnectionString(process.env.CASSANDRA_DSN || '', {
+  protocol: 'cassandra',
+  path: ['sqlectron'],
+  hosts: [{ name: 'localhost', port: 9042 }],
+});
+dbs.cassandra = {
+  host: cassandra.hostname,
+  port: cassandra.port || 9042,
+  database: cassandra.path && cassandra.path[0],
+};
 
 export default dbs;


### PR DESCRIPTION
A continution of the work from #99 and #102, this removes the need for manually specifying the environment variables for a provider if you're using the default one from the `docker-compose.yml` environment or on CI, rather just have to specify the client via `DB_CLIENTS=foo`, greatly simplifying local and CI testing.