### PR TITLE
Add official support for redshift (postgres 8.0)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    env:
+      redshift-version: redshift
+
     strategy:
       matrix:
         include:
@@ -51,10 +54,15 @@ jobs:
       run: docker run --rm -d --name mysql -e "MYSQL_ROOT_PASSWORD=Password12!" -e "MYSQL_DATABASE=sqlectron" -p 3306:3306 -v ${GITHUB_WORKSPACE}/spec/databases/mysql/schema:/docker-entrypoint-initdb.d mysql:${{ matrix.mysql-version }}
     - name: Create MariaDB Container
       run: docker run --rm -d --name mariadb -e "MYSQL_ROOT_PASSWORD=Password12!" -e "MYSQL_DATABASE=sqlectron" -p 3307:3306 -v ${GITHUB_WORKSPACE}/spec/databases/mysql/schema:/docker-entrypoint-initdb.d mariadb:${{ matrix.maraidb-version }}
+
     - name: Create Postgres Container
       run: docker run --rm -d --name postgres -e "POSTGRES_PASSWORD=Password12!" -e "POSTGRES_DB=sqlectron" -p 5432:5432 -v ${GITHUB_WORKSPACE}/spec/databases/postgresql/schema:/docker-entrypoint-initdb.d postgres:${{ matrix.postgres-version }}
+    - name: Create Redshift Container
+      run: docker run --rm -d --name redshift -e "POSTGRES_PASSWORD=Password12!" -e "POSTGRES_DB=sqlectron" -p 5433:5432 -v ${GITHUB_WORKSPACE}/spec/databases/redshift/schema:/docker-entrypoint-initdb.d foundryai/postgres8:${{ matrix.redshift-version }}
+
     - name: Create Cassandra Container
       run: docker run --rm -d --name cassandra -p 9042:9042 -v ${GITHUB_WORKSPACE}/spec/databases/cassandra/schema:/docker-entrypoint-initdb.d  cassandra:${{ matrix.cassandra-version }}
+
     - name: Create SQLServer Container
       run: docker run --rm -d --name sqlserver -p 1433:1433 -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Password12!" -e "MSSQL_COLLATION=${{ matrix.sqlserver-collation }}" -v ${GITHUB_WORKSPACE}/spec/databases/sqlserver/schema:/docker-entrypoint-initdb.d mcr.microsoft.com/mssql/server:2017-latest
 
@@ -82,4 +90,4 @@ jobs:
     - name: Initialize SQLServer Schema
       run: docker exec -i sqlserver /opt/mssql-tools/bin/sqlcmd -S localhost,1433 -U sa -P Password12! -i /docker-entrypoint-initdb.d/schema.sql -d "sqlectron"
 
-    - run: DB_CLIENTS=mysql,mariadb,postgresql,sqlite,sqlserver,cassandra npm run test:coverage
+    - run: DB_CLIENTS=mysql,mariadb,postgresql,redshift,sqlite,sqlserver,cassandra npm run test:coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Create Postgres Container
       run: docker run --rm -d --name postgres -e "POSTGRES_PASSWORD=Password12!" -e "POSTGRES_DB=sqlectron" -p 5432:5432 -v ${GITHUB_WORKSPACE}/spec/databases/postgresql/schema:/docker-entrypoint-initdb.d postgres:${{ matrix.postgres-version }}
     - name: Create Redshift Container
-      run: docker run --rm -d --name redshift -e "POSTGRES_PASSWORD=Password12!" -e "POSTGRES_DB=sqlectron" -p 5433:5432 -v ${GITHUB_WORKSPACE}/spec/databases/redshift/schema:/docker-entrypoint-initdb.d foundryai/postgres8:${{ matrix.redshift-version }}
+      run: docker run --rm -d --name redshift -e "POSTGRES_PASSWORD=Password12!" -e "POSTGRES_DB=sqlectron" -p 5433:5432 -v ${GITHUB_WORKSPACE}/spec/databases/redshift/schema:/docker-entrypoint-initdb.d foundryai/postgres8:${{ env.redshift-version }}
 
     - name: Create Cassandra Container
       run: docker run --rm -d --name cassandra -p 9042:9042 -v ${GITHUB_WORKSPACE}/spec/databases/cassandra/schema:/docker-entrypoint-initdb.d  cassandra:${{ matrix.cassandra-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,13 +52,15 @@ jobs:
 
     - name: Create MySQL Container
       run: docker run --rm -d --name mysql -e "MYSQL_ROOT_PASSWORD=Password12!" -e "MYSQL_DATABASE=sqlectron" -p 3306:3306 -v ${GITHUB_WORKSPACE}/spec/databases/mysql/schema:/docker-entrypoint-initdb.d mysql:${{ matrix.mysql-version }}
+
     - name: Create MariaDB Container
       run: docker run --rm -d --name mariadb -e "MYSQL_ROOT_PASSWORD=Password12!" -e "MYSQL_DATABASE=sqlectron" -p 3307:3306 -v ${GITHUB_WORKSPACE}/spec/databases/mysql/schema:/docker-entrypoint-initdb.d mariadb:${{ matrix.maraidb-version }}
 
     - name: Create Postgres Container
       run: docker run --rm -d --name postgres -e "POSTGRES_PASSWORD=Password12!" -e "POSTGRES_DB=sqlectron" -p 5432:5432 -v ${GITHUB_WORKSPACE}/spec/databases/postgresql/schema:/docker-entrypoint-initdb.d postgres:${{ matrix.postgres-version }}
+
     - name: Create Redshift Container
-      run: docker run --rm -d --name redshift -e "POSTGRES_PASSWORD=Password12!" -e "POSTGRES_DB=sqlectron" -p 5433:5432 -v ${GITHUB_WORKSPACE}/spec/databases/redshift/schema:/docker-entrypoint-initdb.d foundryai/postgres8:${{ env.redshift-version }}
+      run: docker run --rm -d --name redshift -e "POSTGRES_PASSWORD=Password12!" -e "POSTGRES_DATABASE=sqlectron" -p 5433:5432 -v ${GITHUB_WORKSPACE}/spec/databases/redshift/schema:/docker-entrypoint-initdb.d foundryai/postgres8:${{ env.redshift-version }}
 
     - name: Create Cassandra Container
       run: docker run --rm -d --name cassandra -p 9042:9042 -v ${GITHUB_WORKSPACE}/spec/databases/cassandra/schema:/docker-entrypoint-initdb.d  cassandra:${{ matrix.cassandra-version }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,16 @@ services:
     volumes:
       - ./spec/databases/postgresql/schema:/docker-entrypoint-initdb.d
 
+  redshift:
+    image: foundryai/postgres8:redshift
+    ports:
+      - 5433:5432
+    environment:
+      POSTGRES_PASSWORD: password
+      POSTGRES_DATABASE: sqlectron
+    volumes:
+      - ./spec/databases/redshift/schema:/docker-entrypoint-initdb.d
+
   cassandra:
     image: cassandra:3.7
     environment:

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:sqlite": "DB_CLIENTS=sqlite npm run test",
     "test:sqlserver": "DB_CLIENTS=sqlserver npm run test",
     "test:postgresql": "DB_CLIENTS=postgresql npm run test",
+    "test:redshift": "DB_CLIENTS=redshift npm run test",
     "test:cassandra": "DB_CLIENTS=cassandra npm run test",
     "test": "npm run lint && mocha --exit --timeout 40000 --require @babel/register --reporter spec \"./spec/**/*.spec.js\"",
     "test:coverage": "nyc --reporter=text mocha --exit --timeout 4000 --require @babel/register --reporter spec \"./spec/**/*.spec.js\"",

--- a/spec/databases/config.js
+++ b/spec/databases/config.js
@@ -12,7 +12,7 @@ const postgres = new ConnectionString(process.env.POSTGRES_DSN, {
   user: 'postgres',
   password: 'Password12!',
   path: ['sqlectron'],
-  hosts: [{ name: 'localhost', port: 5432 }],
+  hosts: [{ name: '127.0.0.1', port: 5432 }],
 });
 dbs.postgresql = {
   host: postgres.hostname,
@@ -20,6 +20,21 @@ dbs.postgresql = {
   user: postgres.user,
   password: postgres.password,
   database: postgres.path && postgres.path[0],
+};
+
+const redshift = new ConnectionString(process.env.REDSHIFT_DSN, {
+  protocol: 'postgres',
+  user: 'postgres',
+  password: 'Password12!',
+  path: ['sqlectron'],
+  hosts: [{ name: '127.0.0.1', port: 5433 }],
+});
+dbs.redshift = {
+  host: redshift.hostname,
+  port: redshift.port || 5433,
+  user: redshift.user,
+  password: redshift.password,
+  database: redshift.path && redshift.path[0],
 };
 
 const mysql = new ConnectionString(process.env.MYSQL_DSN, {

--- a/spec/databases/redshift/schema/schema.sql
+++ b/spec/databases/redshift/schema/schema.sql
@@ -1,0 +1,26 @@
+CREATE TABLE roles(
+   id             SERIAL PRIMARY KEY,
+   name           TEXT    NOT NULL
+);
+
+CREATE TABLE users(
+   id             SERIAL PRIMARY KEY,
+   username       TEXT    NOT NULL,
+   email          TEXT    NOT NULL,
+   password       TEXT    NOT NULL,
+   role_id        INT REFERENCES roles (id) ON DELETE CASCADE,
+   createdat      DATE    NULL
+);
+
+CREATE OR REPLACE VIEW email_view AS
+  SELECT users.email, users.password
+  FROM users;
+
+CREATE OR REPLACE FUNCTION users_count()
+RETURNS bigint AS $$
+  SELECT COUNT(*) FROM users AS total;
+$$ LANGUAGE SQL;
+
+-- Redshift does not support triggers
+
+CREATE SCHEMA dummy_schema;

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -367,7 +367,7 @@ describe('db', () => {
                 '  id integer NOT NULL,\n' +
                 '  username text NOT NULL,\n' +
                 '  email text NOT NULL,\n' +
-                '  "password" text NOT NULL,\n' +
+                `  ${dbClient === 'postgresql' ? 'password' : '"password"'} text NOT NULL,\n` +
                 '  role_id integer NULL,\n' +
                 '  createdat date NULL\n' +
                 ');\n' +

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -596,6 +596,8 @@ describe('db', () => {
           it('should return CREATE PROCEDURE/FUNCTION script', async () => {
             const [createScript] = await dbConn.getRoutineCreateScript('users_count', 'Procedure');
 
+            console.log(createScript);
+
             if (mysqlClients.includes(dbClient)) {
               expect(createScript).to.contain('CREATE DEFINER=');
               expect(createScript).to.contain([

--- a/src/db/clients/index.js
+++ b/src/db/clients/index.js
@@ -37,6 +37,15 @@ export const CLIENTS = [
     ],
   },
   {
+    key: 'redshift',
+    name: 'Redshift',
+    defaultDatabase: 'postgres',
+    defaultPort: 5432,
+    disabledFeatures: [
+      'server:domain',
+    ],
+  },
+  {
     key: 'sqlserver',
     name: 'Microsoft SQL Server',
     defaultPort: 1433,
@@ -79,6 +88,7 @@ export default {
   mysql,
   mariadb: mysql,
   postgresql,
+  redshift: postgresql,
   sqlserver,
   sqlite,
   cassandra,

--- a/src/db/clients/postgresql.js
+++ b/src/db/clients/postgresql.js
@@ -427,12 +427,21 @@ export async function getViewCreateScript(conn, view, schema) {
 
 export async function getRoutineCreateScript(conn, routine, _, schema) {
   const sql = `
+    SELECT prosrc
+    FROM pg_proc p
+    LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+    WHERE p.proname = $1
+    AND n.nspname = $2
+  `;
+  /*
+  const sql = `
     SELECT pg_get_functiondef(p.oid)
     FROM pg_proc p
     LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
     WHERE proname = $1
     AND n.nspname = $2
   `;
+  */
 
   const params = [
     routine,
@@ -441,7 +450,7 @@ export async function getRoutineCreateScript(conn, routine, _, schema) {
 
   const data = await driverExecuteQuery(conn, { query: sql, params });
 
-  return data.rows.map((row) => row.pg_get_functiondef);
+  return data.rows.map((row) => row.prosrc);
 }
 
 export function wrapIdentifier(value) {


### PR DESCRIPTION
This adds proper testing support for redshift (postgres 8.0), to ensure that the codebase works as expected. During this work, this revealed that the getting the create table and routine sql functions were broken due to using features added in later versions of postgres.

Closes #96