### PR TITLE
Fix variable name typo in getQuerySelectTop

### DIFF
--- a/src/db/client.js
+++ b/src/db/client.js
@@ -199,7 +199,7 @@ function listDatabases(server, database, filter) {
 async function getQuerySelectTop(server, database, table, schema, limit) {
   checkIsConnected(server, database);
   let limitValue = limit;
-  if (typeof _limit === 'undefined') {
+  if (typeof limit === 'undefined') {
     await loadConfigLimit();
     limitValue = typeof limitSelect !== 'undefined' ? limitSelect : DEFAULT_LIMIT;
   }


### PR DESCRIPTION
This fixes a typo in the `getQuerySelectTop` function where no matter what the limit that was passed to the function, it would always be overwritten due to a typo of comparing `_limit` instead of `limit`. This corrects it so that it will use `limit` if passed to the function, else it will enter the else branch to get a default limit.