### PR TITLE
Fix query function for sqlserver client

### DIFF
--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -767,7 +767,7 @@ describe('db', () => {
             let expected;
             if (dbClient === 'sqlserver') {
               expected = 1;
-            } else if (dbClient === '') {
+            } else if (dbClient === 'sqlite') {
               expected = 0;
             }
             expect(result[0].affectedRows).to.eql(expected);

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -762,8 +762,8 @@ describe('db', () => {
           it('select function return result', async () => {
             const query = dbConn.query('SELECT CURRENT_TIMESTAMP');
             const result = await query.execute();
-            console.log(result);
-            expect(result[0].affectedRows).to.eql(0);
+            expect(result[0].rowCount).to.eql(1);
+            expect(result[0].affectedRows).to.eql(undefined);
           });
         }
 

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -758,6 +758,13 @@ describe('db', () => {
               }, 5000);
             });
           });
+
+          it('select function return result', async () => {
+            const query = dbConn.query('SELECT CURRENT_TIMESTAMP');
+            const result = await query.execute();
+            console.log(result);
+            expect(result[0].affectedRows).to.eql(0);
+          });
         }
 
         describe('.executeQuery', () => {

--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -759,11 +759,18 @@ describe('db', () => {
             });
           });
 
-          it('select function return result', async () => {
+          it('should query single result from function', async () => {
             const query = dbConn.query('SELECT CURRENT_TIMESTAMP');
             const result = await query.execute();
+            expect(result[0].rows[0]).to.be.not.null;
             expect(result[0].rowCount).to.eql(1);
-            expect(result[0].affectedRows).to.eql(undefined);
+            let expected;
+            if (dbClient === 'sqlserver') {
+              expected = 1;
+            } else if (dbClient === '') {
+              expected = 0;
+            }
+            expect(result[0].affectedRows).to.eql(expected);
           });
         }
 

--- a/src/db/clients/sqlserver.js
+++ b/src/db/clients/sqlserver.js
@@ -89,9 +89,9 @@ export function query(conn, queryText) {
           queryRequest = request;
 
           const result = await promiseQuery;
-          const data = request.multiple ? result.datasets : result.dataset;
-          const affectedRows = result.affectedRows ?
-            result.affectedRows.reduce((a, b) => a + b, 0) :
+          const data = request.multiple ? result.recordsets : result.recordset;
+          const affectedRows = result.rowsAffected ?
+            result.rowsAffected.reduce((a, b) => a + b, 0) :
             undefined;
 
           const commands = identifyCommands(queryText).map((item) => item.type);

--- a/src/db/clients/sqlserver.js
+++ b/src/db/clients/sqlserver.js
@@ -90,7 +90,9 @@ export function query(conn, queryText) {
 
           const result = await promiseQuery;
           const data = request.multiple ? result.datasets : result.dataset;
-          const affectedRows = result.affectedRows.reduce((a, b) => a + b, 0);
+          const affectedRows = result.affectedRows ?
+            result.affectedRows.reduce((a, b) => a + b, 0) :
+            undefined;
 
           const commands = identifyCommands(queryText).map((item) => item.type);
 


### PR DESCRIPTION
Closes #118 

Looks like sqlserver would error out on any usage of `query()` function. This fixes that, and adds a test case for the regression. This does show that sqlserver and sqlite differ in their result from the mysql + postgres clients. This should be rectified in 9.0 so that all clients equally return `0` here.