### PR TITLE
rewrite usage of array bitwise indexOf to includes

### DIFF
--- a/spec/db.spec.js
+++ b/spec/db.spec.js
@@ -33,7 +33,7 @@ const mysqlClients = ['mysql', 'mariadb'];
 
 describe('db', () => {
   const dbClients = dbsToTest.length ? dbsToTest : SUPPORTED_DB_CLIENTS;
-  if (dbClients.some((dbClient) => !~SUPPORTED_DB_CLIENTS.indexOf(dbClient))) {
+  if (dbClients.some((dbClient) => !SUPPORTED_DB_CLIENTS.includes(dbClient))) {
     throw new Error('Invalid selected db client for tests');
   }
 

--- a/src/db/clients/mysql.js
+++ b/src/db/clients/mysql.js
@@ -510,11 +510,11 @@ export function filterDatabase(item, { database } = {}, databaseField) {
 
   const { only, ignore } = database;
 
-  if (only && only.length && !~only.indexOf(value)) {
+  if (only && only.length && !only.includes(value)) {
     return false;
   }
 
-  if (ignore && ignore.length && ~ignore.indexOf(value)) {
+  if (ignore && ignore.length && ignore.includes(value)) {
     return false;
   }
 


### PR DESCRIPTION
Some code clean-up here where we can use the [`Array.prototype.includes`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes) method to more easily determine list membership instead of using bitwise operators.