### PR TITLE
remove scriptCreateTable from sqlite disabled features

### DIFF
--- a/src/db/clients/index.js
+++ b/src/db/clients/index.js
@@ -64,7 +64,6 @@ export const CLIENTS = [
       'server:schema',
       'server:domain',
       'server:ssh',
-      'scriptCreateTable',
       'cancelQuery',
     ],
   },


### PR DESCRIPTION
Closes #123 

Still need to do #122 as sqlite at least does not return stuff with a closing `;`, but that will be a separate PR.